### PR TITLE
New resource & data source 'azuread_group'

### DIFF
--- a/azuread/config.go
+++ b/azuread/config.go
@@ -29,6 +29,7 @@ type ArmClient struct {
 
 	// azure AD clients
 	applicationsClient      graphrbac.ApplicationsClient
+	groupsClient            graphrbac.GroupsClient
 	servicePrincipalsClient graphrbac.ServicePrincipalsClient
 }
 
@@ -72,6 +73,9 @@ func getArmClient(authCfg *authentication.Config) (*ArmClient, error) {
 func (c *ArmClient) registerGraphRBACClients(endpoint, tenantID string, authorizer autorest.Authorizer) {
 	c.applicationsClient = graphrbac.NewApplicationsClientWithBaseURI(endpoint, tenantID)
 	configureClient(&c.applicationsClient.Client, authorizer)
+
+	c.groupsClient = graphrbac.NewGroupsClientWithBaseURI(endpoint, tenantID)
+	configureClient(&c.groupsClient.Client, authorizer)
 
 	c.servicePrincipalsClient = graphrbac.NewServicePrincipalsClientWithBaseURI(endpoint, tenantID)
 	configureClient(&c.servicePrincipalsClient.Client, authorizer)

--- a/azuread/data_source_group.go
+++ b/azuread/data_source_group.go
@@ -1,0 +1,98 @@
+package azuread
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/services/graphrbac/1.6/graphrbac"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azuread/azuread/helpers/ar"
+	"github.com/terraform-providers/terraform-provider-azuread/azuread/helpers/validate"
+)
+
+func dataGroup() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceActiveDirectoryGroupRead,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"object_id"},
+				ValidateFunc:  validate.NoEmptyStrings,
+			},
+
+			"object_id": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"name"},
+				ValidateFunc:  validate.UUID,
+			},
+		},
+	}
+}
+
+func dataSourceActiveDirectoryGroupRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).groupsClient
+	ctx := meta.(*ArmClient).StopContext
+
+	var adgroup graphrbac.ADGroup
+	var groupObj *graphrbac.ADGroup
+
+	if oId, ok := d.GetOk("object_id"); ok {
+		// use the object_id to find the Azure AD group
+
+		objectId := oId.(string)
+		resp, err := client.Get(ctx, objectId)
+		if err != nil {
+			if ar.ResponseWasNotFound(resp.Response) {
+				return fmt.Errorf("Error: AzureAD Group with ID %q was not found", objectId)
+			}
+
+			return fmt.Errorf("Error making Read request on AzureAD Group with ID %q: %+v", objectId, err)
+		}
+
+		adgroup = resp
+
+	} else {
+
+		// use the name to find the Azure AD group
+		name := d.Get("name").(string)
+		filter := fmt.Sprintf("displayName eq '%s'", name)
+		log.Printf("[DEBUG] [data_source_azuread_group] Using filter %q", filter)
+
+		resp, err := client.ListComplete(ctx, filter)
+		if err != nil {
+			return fmt.Errorf("Error listing Azure AD groups: %+v", err)
+		}
+
+		for _, v := range *resp.Response().Value {
+			if v.DisplayName != nil {
+				if strings.EqualFold(*v.DisplayName, name) {
+					log.Printf("[DEBUG] [data_source_azuread_group] %q (API result) matches %q (given value). The group has the objectId: %q", *v.DisplayName, name, *v.ObjectID)
+					groupObj = &v
+					break
+				} else {
+					log.Printf("[DEBUG] [data_source_azuread_group] %q (API result) does not match %q (given value)", *v.DisplayName, name)
+				}
+			}
+		}
+		if groupObj == nil {
+			return fmt.Errorf("Couldn't locate a Azure AD group with a name of %q", name)
+		}
+
+		adgroup = *groupObj
+	}
+
+	d.SetId(*adgroup.ObjectID)
+	d.Set("object_id", adgroup.ObjectID)
+	d.Set("name", adgroup.DisplayName)
+
+	return nil
+}

--- a/azuread/data_source_group.go
+++ b/azuread/data_source_group.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/graphrbac/1.6/graphrbac"
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/terraform-providers/terraform-provider-azuread/azuread/helpers/ar"
 	"github.com/terraform-providers/terraform-provider-azuread/azuread/helpers/validate"
 )
 
@@ -19,19 +18,9 @@ func dataGroup() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Computed:      true,
-				ConflictsWith: []string{"object_id"},
-				ValidateFunc:  validate.NoEmptyStrings,
-			},
-
-			"object_id": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Computed:      true,
-				ConflictsWith: []string{"name"},
-				ValidateFunc:  validate.UUID,
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validate.NoEmptyStrings,
 			},
 		},
 	}
@@ -44,58 +33,39 @@ func dataSourceActiveDirectoryGroupRead(d *schema.ResourceData, meta interface{}
 	var adgroup graphrbac.ADGroup
 	var groupObj *graphrbac.ADGroup
 
-	if oId, ok := d.GetOk("object_id"); ok {
-		// use the object_id to find the Azure AD group
+	// use the name to find the Azure AD group
+	name := d.Get("name").(string)
+	filter := fmt.Sprintf("displayName eq '%s'", name)
+	log.Printf("[DEBUG] Using filter %q", filter)
 
-		objectId := oId.(string)
-		resp, err := client.Get(ctx, objectId)
-		if err != nil {
-			if ar.ResponseWasNotFound(resp.Response) {
-				return fmt.Errorf("Error: AzureAD Group with ID %q was not found", objectId)
-			}
-
-			return fmt.Errorf("Error making Read request on AzureAD Group with ID %q: %+v", objectId, err)
-		}
-
-		adgroup = resp
-
-	} else {
-
-		// use the name to find the Azure AD group
-		name := d.Get("name").(string)
-		filter := fmt.Sprintf("displayName eq '%s'", name)
-		log.Printf("[DEBUG] Using filter %q", filter)
-
-		resp, err := client.ListComplete(ctx, filter)
-		if err != nil {
-			return fmt.Errorf("Error listing Azure AD groups: %+v", err)
-		}
-
-		for _, v := range *resp.Response().Value {
-			if v.DisplayName == nil {
-				//no DisplayName returned, continue with the next iteration
-				continue
-			} else {
-				if *v.DisplayName == name {
-					log.Printf("[DEBUG] %q (API result) matches %q (given value). The group has the objectId: %q", *v.DisplayName, name, *v.ObjectID)
-					groupObj = &v
-					break
-				} else {
-					log.Printf("[DEBUG] %q (API result) does not match %q (given value)", *v.DisplayName, name)
-				}
-			}
-		}
-
-		if groupObj == nil {
-			return fmt.Errorf("Couldn't locate a Azure AD group with a name of %q", name)
-		}
-
-		adgroup = *groupObj
+	resp, err := client.ListComplete(ctx, filter)
+	if err != nil {
+		return fmt.Errorf("Error listing Azure AD groups: %+v", err)
 	}
+
+	for _, v := range *resp.Response().Value {
+		if v.DisplayName == nil {
+			//no DisplayName returned, continue with the next iteration
+			continue
+		} else {
+			if *v.DisplayName == name {
+				log.Printf("[DEBUG] %q (API result) matches %q (given value). The group has the objectId: %q", *v.DisplayName, name, *v.ObjectID)
+				groupObj = &v
+				break
+			} else {
+				log.Printf("[DEBUG] %q (API result) does not match %q (given value)", *v.DisplayName, name)
+			}
+		}
+	}
+
+	if groupObj == nil {
+		return fmt.Errorf("Couldn't locate a Azure AD group with a name of %q", name)
+	}
+
+	adgroup = *groupObj
 
 	d.SetId(*adgroup.ObjectID)
 	d.Set("object_id", adgroup.ObjectID)
-	d.Set("name", adgroup.DisplayName)
 
 	return nil
 }

--- a/azuread/data_source_group.go
+++ b/azuread/data_source_group.go
@@ -3,7 +3,6 @@ package azuread
 import (
 	"fmt"
 	"log"
-	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/services/graphrbac/1.6/graphrbac"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -77,7 +76,7 @@ func dataSourceActiveDirectoryGroupRead(d *schema.ResourceData, meta interface{}
 				//no DisplayName returned, continue with the next iteration
 				continue
 			} else {
-				if strings.EqualFold(*v.DisplayName, name) {
+				if *v.DisplayName == name {
 					log.Printf("[DEBUG] %q (API result) matches %q (given value). The group has the objectId: %q", *v.DisplayName, name, *v.ObjectID)
 					groupObj = &v
 					break

--- a/azuread/data_source_group_test.go
+++ b/azuread/data_source_group_test.go
@@ -1,0 +1,85 @@
+package azuread
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDataSourceAzureADGroup_byObjectId(t *testing.T) {
+	dataSourceName := "data.azuread_group.test"
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	config := testAccDataSourceAzureADGroup_objectId(id)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureADGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureADGroup(id),
+			},
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureADGroupExists(dataSourceName),
+					resource.TestCheckResourceAttr(dataSourceName, "name", fmt.Sprintf("acctest%s", id)),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceAzureADGroup_byName(t *testing.T) {
+	dataSourceName := "data.azuread_group.test"
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	config := testAccDataSourceAzureADGroup_name(id)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureADGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureADGroup(id),
+			},
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureADGroupExists(dataSourceName),
+					resource.TestCheckResourceAttr(dataSourceName, "name", fmt.Sprintf("acctest%s", id)),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAzureADGroup_objectId(id string) string {
+	template := testAccAzureADGroup(id)
+	return fmt.Sprintf(`
+%s
+
+data "azuread_group" "test" {
+  object_id = "${azuread_group.test.id}"
+}
+`, template)
+}
+
+func testAccDataSourceAzureADGroup_name(id string) string {
+	template := testAccAzureADGroup(id)
+	return fmt.Sprintf(`
+%s
+
+data "azuread_group" "test" {
+  name = "${azuread_group.test.name}"
+}
+`, template)
+}

--- a/azuread/data_source_group_test.go
+++ b/azuread/data_source_group_test.go
@@ -8,33 +8,6 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccDataSourceAzureADGroup_byObjectId(t *testing.T) {
-	dataSourceName := "data.azuread_group.test"
-	id, err := uuid.GenerateUUID()
-	if err != nil {
-		t.Fatal(err)
-	}
-	config := testAccDataSourceAzureADGroup_objectId(id)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureADGroupDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAzureADGroup(id),
-			},
-			{
-				Config: config,
-				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureADGroupExists(dataSourceName),
-					resource.TestCheckResourceAttr(dataSourceName, "name", fmt.Sprintf("acctest%s", id)),
-				),
-			},
-		},
-	})
-}
-
 func TestAccDataSourceAzureADGroup_byName(t *testing.T) {
 	dataSourceName := "data.azuread_group.test"
 	id, err := uuid.GenerateUUID()
@@ -60,17 +33,6 @@ func TestAccDataSourceAzureADGroup_byName(t *testing.T) {
 			},
 		},
 	})
-}
-
-func testAccDataSourceAzureADGroup_objectId(id string) string {
-	template := testAccAzureADGroup(id)
-	return fmt.Sprintf(`
-%s
-
-data "azuread_group" "test" {
-  object_id = "${azuread_group.test.id}"
-}
-`, template)
 }
 
 func testAccDataSourceAzureADGroup_name(id string) string {

--- a/azuread/provider.go
+++ b/azuread/provider.go
@@ -75,11 +75,13 @@ func Provider() terraform.ResourceProvider {
 
 		DataSourcesMap: map[string]*schema.Resource{
 			"azuread_application":       dataApplication(),
+			"azuread_group":             dataGroup(),
 			"azuread_service_principal": dataServicePrincipal(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
 			"azuread_application":                resourceApplication(),
+			"azuread_group":                      resourceGroup(),
 			"azuread_service_principal":          resourceServicePrincipal(),
 			"azuread_service_principal_password": resourceServicePrincipalPassword(),
 		},

--- a/azuread/resource_group.go
+++ b/azuread/resource_group.go
@@ -61,7 +61,7 @@ func resourceGroupRead(d *schema.ResourceData, meta interface{}) error {
 	resp, err := client.Get(ctx, d.Id())
 	if err != nil {
 		if ar.ResponseWasNotFound(resp.Response) {
-			log.Printf("[DEBUG] [resource_azuread_group] Azure AD group with id %q was not found - removing from state", d.Id())
+			log.Printf("[DEBUG] Azure AD group with id %q was not found - removing from state", d.Id())
 			d.SetId("")
 			return nil
 		}

--- a/azuread/resource_group.go
+++ b/azuread/resource_group.go
@@ -1,0 +1,88 @@
+package azuread
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/Azure/azure-sdk-for-go/services/graphrbac/1.6/graphrbac"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+	"github.com/terraform-providers/terraform-provider-azuread/azuread/helpers/ar"
+	"github.com/terraform-providers/terraform-provider-azuread/azuread/helpers/p"
+)
+
+func resourceGroup() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceGroupCreate,
+		Read:   resourceGroupRead,
+		Delete: resourceGroupDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.NoZeroValues,
+			},
+		},
+	}
+}
+
+func resourceGroupCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).groupsClient
+	ctx := meta.(*ArmClient).StopContext
+
+	name := d.Get("name").(string)
+
+	properties := graphrbac.GroupCreateParameters{
+		DisplayName:     &name,
+		MailEnabled:     p.Bool(false), //we're defaulting to false, as the API currently only supports the creation of non-mail enabled security groups.
+		MailNickname:    &name,
+		SecurityEnabled: p.Bool(true), //we're defaulting to true, as the API currently only supports the creation of non-mail enabled security groups.
+	}
+
+	group, err := client.Create(ctx, properties)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(*group.ObjectID)
+
+	return resourceGroupRead(d, meta)
+}
+
+func resourceGroupRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).groupsClient
+	ctx := meta.(*ArmClient).StopContext
+
+	resp, err := client.Get(ctx, d.Id())
+	if err != nil {
+		if ar.ResponseWasNotFound(resp.Response) {
+			log.Printf("[DEBUG] [resource_azuread_group] Azure AD group with id %q was not found - removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("Error retrieving Azure AD Group with ID %q: %+v", d.Id(), err)
+	}
+
+	d.Set("name", resp.DisplayName)
+
+	return nil
+}
+
+func resourceGroupDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).groupsClient
+	ctx := meta.(*ArmClient).StopContext
+
+	if resp, err := client.Delete(ctx, d.Id()); err != nil {
+		if !ar.ResponseWasNotFound(resp) {
+			return fmt.Errorf("Error Deleting Azure AD Group with ID %q: %+v", d.Id(), err)
+		}
+	}
+
+	return nil
+}

--- a/azuread/resource_group_test.go
+++ b/azuread/resource_group_test.go
@@ -1,0 +1,123 @@
+package azuread
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/terraform-providers/terraform-provider-azuread/azuread/helpers/ar"
+)
+
+func TestAccAzureADGroup_basic(t *testing.T) {
+	resourceName := "azuread_group.test"
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	config := testAccAzureADGroup(id)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureADGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureADGroupExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("acctest%s", id)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAzureADGroup_complete(t *testing.T) {
+	resourceName := "azuread_group.test"
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	config := testAccAzureADGroup(id)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureADGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureADGroupExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("acctest%s", id)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testCheckAzureADGroupExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %q", name)
+		}
+
+		client := testAccProvider.Meta().(*ArmClient).groupsClient
+		ctx := testAccProvider.Meta().(*ArmClient).StopContext
+		resp, err := client.Get(ctx, rs.Primary.ID)
+
+		if err != nil {
+			if ar.ResponseWasNotFound(resp.Response) {
+				return fmt.Errorf("Bad: Azure AD Group %q does not exist", rs.Primary.ID)
+			}
+			return fmt.Errorf("Bad: Get on Azure AD groupsClient: %+v", err)
+		}
+
+		return nil
+	}
+}
+
+func testCheckAzureADGroupDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "azuread_group" {
+			continue
+		}
+
+		client := testAccProvider.Meta().(*ArmClient).groupsClient
+		ctx := testAccProvider.Meta().(*ArmClient).StopContext
+		resp, err := client.Get(ctx, rs.Primary.ID)
+
+		if err != nil {
+			if ar.ResponseWasNotFound(resp.Response) {
+				return nil
+			}
+
+			return err
+		}
+
+		return fmt.Errorf("Azure AD group still exists:\n%#v", resp)
+	}
+
+	return nil
+}
+
+func testAccAzureADGroup(id string) string {
+	return fmt.Sprintf(`
+resource "azuread_group" "test" {
+  name = "acctest%s"
+}
+`, id)
+}

--- a/website/azuread.erb
+++ b/website/azuread.erb
@@ -51,6 +51,10 @@
                   <a href="/docs/providers/azuread/d/application.html">azuread_application</a>
                 </li>
 
+                <li<%= sidebar_current("docs-azuread-datasource-azuread-group") %>>
+                  <a href="/docs/providers/azuread/d/group.html">azuread_group</a>
+                </li>
+
                 <li<%= sidebar_current("docs-azuread-datasource-azuread-application") %>>
                   <a href="/docs/providers/azuread/d/service_principal.html">azuread_service_principal</a>
                 </li>
@@ -64,6 +68,10 @@
 
                 <li<%= sidebar_current("docs-azuread-resource-azuread-application") %>>
                   <a href="/docs/providers/azuread/r/application.html">azuread_application</a>
+                </li>
+
+                <li<%= sidebar_current("docs-azuread-resource-azuread-group") %>>
+                  <a href="/docs/providers/azuread/r/group.html">azuread_group</a>
                 </li>
 
                 <li<%= sidebar_current("docs-azuread-resource-azuread-service-principal-x") %>>

--- a/website/docs/d/group.html.markdown
+++ b/website/docs/d/group.html.markdown
@@ -25,7 +25,7 @@ data "azuread_group" "test_group" {
 
 The following arguments are supported:
 
-* `name` - (Required) The UUID of the Azure AD Group we want to lookup.
+* `name` - (Required) The Name of the Azure AD Group we want to lookup.
 
 ~> **WARNING:** `name` is not unique within Azure Active Directory. The data source will only return the first Group found.
 

--- a/website/docs/d/group.html.markdown
+++ b/website/docs/d/group.html.markdown
@@ -13,14 +13,6 @@ Gets information about an Azure Active Directory group.
 
 -> **NOTE:** If you're authenticating using a Service Principal then it must have permissions to `Read directory data` within the `Windows Azure Active Directory` API.
 
-## Example Usage (by Object ID)
-
-```hcl
-data "azuread_group" "test_group" {
-  object_id = "78722cfc-8946-11e8-95f1-2200ec79ad01"
-}
-```
-
 ## Example Usage (by Group Display Name)
 
 ```hcl
@@ -33,11 +25,7 @@ data "azuread_group" "test_group" {
 
 The following arguments are supported:
 
-* `object_id` - (Optional) The UUID of the Azure AD Group we want to lookup.
-
-* `name` - (Optional) The UUID of the Azure AD Group we want to lookup.
-
--> **NOTE:** At least one of `name` or `object_id` must be specified.
+* `name` - (Required) The UUID of the Azure AD Group we want to lookup.
 
 ~> **WARNING:** `name` is not unique within Azure Active Directory. The data source will only return the first Group found.
 
@@ -45,6 +33,4 @@ The following arguments are supported:
 
 The following attributes are exported:
 
-* `id` - The Object ID for the Azure AD Group.
-* `object_id` - The Object ID for the Azure AD Group.
-* `name` - The Display Name for the Azure AD Group.
+* `id` - The Object ID of the Azure AD Group.

--- a/website/docs/d/group.html.markdown
+++ b/website/docs/d/group.html.markdown
@@ -33,13 +33,13 @@ data "azuread_group" "test_group" {
 
 The following arguments are supported:
 
-* `object_id` - (Optional) The ID of the Azure AD Group we want to lookup.
+* `object_id` - (Optional) The UUID of the Azure AD Group we want to lookup.
 
-* `name` - (Optional) The ID of the Azure AD Group we want to loopup.
+* `name` - (Optional) The UUID of the Azure AD Group we want to lookup.
 
 -> **NOTE:** At least one of `name` or `object_id` must be specified.
 
--> **WARNING:** `name` is not unique within Azure Active Directory. The data source will only return the first Group found.
+~> **WARNING:** `name` is not unique within Azure Active Directory. The data source will only return the first Group found.
 
 ## Attributes Reference
 

--- a/website/docs/d/group.html.markdown
+++ b/website/docs/d/group.html.markdown
@@ -1,0 +1,50 @@
+---
+layout: "azuread"
+page_title: "Azure Active Directory: azuread_group"
+sidebar_current: "docs-azuread-datasource-azuread-group"
+description: |-
+  Gets information about an Azure Active Directory group.
+
+---
+
+# Data Source: azuread_group
+
+Gets information about an Azure Active Directory group.
+
+-> **NOTE:** If you're authenticating using a Service Principal then it must have permissions to both `Read directory data` within the `Windows Azure Active Directory` API.
+
+## Example Usage (by Object ID)
+
+```hcl
+data "azuread_group" "test_group" {
+  object_id = "78722cfc-8946-11e8-95f1-2200ec79ad01"
+}
+```
+
+## Example Usage (by Group Display Name)
+
+```hcl
+data "azuread_group" "test_group" {
+  name = "MyTestGroup"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `object_id` - (Optional) The ID of the Azure AD Group we want to lookup.
+
+* `name` - (Optional) The ID of the Azure AD Group we want to loopup.
+
+-> **NOTE:** At least one of `name` or `object_id` must be specified.
+
+-> **WARNING:** `name` is not unique within Azure Active Directory. The data source will only return the first Group found.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The Object ID for the Azure AD Group.
+* `object_id` - The Object ID for the Azure AD Group.
+* `name` - The Display Name for the Azure AD Group.

--- a/website/docs/d/group.html.markdown
+++ b/website/docs/d/group.html.markdown
@@ -11,7 +11,7 @@ description: |-
 
 Gets information about an Azure Active Directory group.
 
--> **NOTE:** If you're authenticating using a Service Principal then it must have permissions to both `Read directory data` within the `Windows Azure Active Directory` API.
+-> **NOTE:** If you're authenticating using a Service Principal then it must have permissions to `Read directory data` within the `Windows Azure Active Directory` API.
 
 ## Example Usage (by Object ID)
 

--- a/website/docs/r/group.markdown
+++ b/website/docs/r/group.markdown
@@ -1,0 +1,53 @@
+---
+layout: "azuread"
+page_title: "Azure Active Directory: azuread_group"
+sidebar_current: "docs-azuread-resource-azuread-group"
+description: |-
+  Manages a Group within Azure Active Directory.
+
+---
+
+# azuread_group
+
+Manages a Group within Azure Active Directory.
+
+-> **NOTE:** If you're authenticating using a Service Principal then it must have permissions to `Read and write all groups` within the `Windows Azure Active Directory` API.
+
+-> **NOTE:** Additionally, due to a limitation within the API, you have to assign **one** of the following Azure Active Directory Roles to the Service Principal to be able to delete Groups:
+
+* User Account Administrator
+* Company Administrator
+
+You can assign one of the required Azure Active Directory Roles with PowerShell. Please refer to [this documentation](https://docs.microsoft.com/en-us/powershell/module/azuread/add-azureaddirectoryrolemember) for more details.
+
+## Example Usage
+
+```hcl
+resource "azuread_group" "my_group" {
+  name = "MyGroup"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The display name for the Group.
+
+-> **NOTE:** Group names are not unique within Azure Active Directory.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The Object ID of the Group.
+
+* `name` - The Display Name of the Group.
+
+## Import
+
+Azure Active Directory Groups can be imported using the `object id`, e.g.
+
+```shell
+terraform import azuread_group.my_group 00000000-0000-0000-0000-000000000000
+```

--- a/website/docs/r/group.markdown
+++ b/website/docs/r/group.markdown
@@ -18,7 +18,7 @@ Manages a Group within Azure Active Directory.
 * User Account Administrator
 * Company Administrator
 
-You can assign one of the required Azure Active Directory Roles with PowerShell. Please refer to [this documentation](https://docs.microsoft.com/en-us/powershell/module/azuread/add-azureaddirectoryrolemember) for more details.
+You can assign one of the required Azure Active Directory Roles with the **AzureAD PowerShell Module**, which is available for Windows PowerShell or in the Azure Cloud Shell. Please refer to [this documentation](https://docs.microsoft.com/en-us/powershell/module/azuread/add-azureaddirectoryrolemember) for more details.
 
 ## Example Usage
 


### PR DESCRIPTION
This PR adds a new resource and data source for Azure Active Directory groups.

The is based on the PR terraform-providers/terraform-provider-azurerm#1839

- [x] New data source 'azuread_group'
- [x] New resource 'azuread_group'
- [x] Add markdown documentation
- [x] Add tests

## Example Usage

```hcl

// This creates a new Azure AD group with the display name "my_group"
resource "azuread_group" "my_group" {
 name = "my_group"
}

// This queries an Azure AD group by ID
data "azuread_group" "my_group_by_id" {
  object_id = "78722cfc-8946-11e8-95f1-2200ec79ad01"
}

// This queries an Azure AD group by Name
data "azuread_group" "my_group_by_name" {
  name = "my_group"
}
```

The following attributes are exported:

* `id` - The Object ID for the Azure AD Group.
* `name` - The Display Name for the Azure AD Group.