### PR TITLE
WIP: add azuread_group data source

### DIFF
--- a/azuread/config.go
+++ b/azuread/config.go
@@ -30,6 +30,7 @@ type ArmClient struct {
 	// azure AD clients
 	applicationsClient      graphrbac.ApplicationsClient
 	servicePrincipalsClient graphrbac.ServicePrincipalsClient
+	groupsClient            graphrbac.GroupsClient
 }
 
 // getArmClient is a helper method which returns a fully instantiated *ArmClient based on the auth Config's current settings.
@@ -75,6 +76,9 @@ func (c *ArmClient) registerGraphRBACClients(endpoint, tenantID string, authoriz
 
 	c.servicePrincipalsClient = graphrbac.NewServicePrincipalsClientWithBaseURI(endpoint, tenantID)
 	configureClient(&c.servicePrincipalsClient.Client, authorizer)
+
+	c.groupsClient = graphrbac.NewGroupsClientWithBaseURI(endpoint, tenantID)
+	configureClient(&c.groupsClient.Client, authorizer)
 }
 
 func configureClient(client *autorest.Client, auth autorest.Authorizer) {

--- a/azuread/data_source_group.go
+++ b/azuread/data_source_group.go
@@ -1,0 +1,91 @@
+package azuread
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/Azure/azure-sdk-for-go/services/graphrbac/1.6/graphrbac"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azuread/azuread/helpers/ar"
+)
+
+func dataSourceArmActiveDirectoryGroup() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceArmActiveDirectoryGroupRead,
+
+		Schema: map[string]*schema.Schema{
+			"object_id": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"display_name", "display_name"},
+			},
+
+			"display_name": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"object_id", "object_id"},
+			},
+
+			"mail": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceArmActiveDirectoryGroupRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).groupsClient
+	ctx := meta.(*ArmClient).StopContext
+
+	var group *graphrbac.ADGroup
+
+	if v, ok := d.GetOk("object_id"); ok {
+		objectId := v.(string)
+		result, err := client.Get(ctx, objectId)
+		if err != nil {
+			if ar.ResponseWasNotFound(result.Response) {
+				return fmt.Errorf("Group with Object ID %q was not found!", objectId)
+			}
+
+			return fmt.Errorf("Error retrieving Group with Object ID %q: %+v", objectId, err)
+		}
+
+		group = &result
+
+	} else if v, ok := d.GetOk("display_name"); ok {
+		displayName := v.(string)
+		filter := fmt.Sprintf("displayName eq '%s'", displayName)
+		log.Printf("[DEBUG] [data_source_azuread_group] Using filter %q", filter)
+
+		results, err := client.ListComplete(ctx, filter)
+		if err != nil {
+			return fmt.Errorf("Error listing Groups: %+v", err)
+		}
+
+		for _, result := range *results.Response().Value {
+			if result.DisplayName == nil {
+				continue
+			}
+
+			if *result.DisplayName == displayName {
+				group = &result
+				break
+			}
+		}
+
+		if group == nil {
+			return fmt.Errorf("A Group with the Display Name %q was not found", displayName)
+		}
+	}
+
+	d.SetId(*group.ObjectID)
+	d.Set("display_name", group.DisplayName)
+	d.Set("object_id", group.ObjectID)
+	d.Set("mail", group.Mail)
+
+	return nil
+}

--- a/azuread/data_source_group_test.go
+++ b/azuread/data_source_group_test.go
@@ -1,0 +1,99 @@
+package azuread
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/terraform-providers/terraform-provider-azuread/azuread/helpers/ar"
+)
+
+func TestAccDataSourceAzureADGroup_byDisplayName(t *testing.T) {
+	dataSourceName := "data.azuread_group.test"
+	id := uuid.New().String()
+	config := testAccDataSourceAzureRMAzureADGroup_byDisplayName(id)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		// CheckDestroy:
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMActiveDirectoryServiceGroupExists(dataSourceName),
+					resource.TestCheckResourceAttrSet(dataSourceName, "mail"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "object_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "display_name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceAzureRMAzureADGroup_byObjectId(t *testing.T) {
+	dataSourceName := "data.azuread_group.test"
+	id := uuid.New().String()
+	config := testAccDataSourceAzureRMAzureADGroup_byObjectId(id)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		// CheckDestroy:
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMActiveDirectoryServiceGroupExists(dataSourceName),
+					resource.TestCheckResourceAttrSet(dataSourceName, "mail"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "object_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "display_name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAzureRMAzureADGroup_byDisplayName(id string) string {
+	return fmt.Sprintf(`
+
+data "azuread_group" "test" {
+  display_name = "my-cool-group"
+}
+`)
+}
+
+func testAccDataSourceAzureRMAzureADGroup_byObjectId(id string) string {
+	return fmt.Sprintf(`
+
+data "azuread_group" "test" {
+  object_id = "30a6a0d5-fcb4-xxxx-xxxx-98bfb06a67a1"
+}
+`)
+}
+
+func testCheckAzureRMActiveDirectoryServiceGroupExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %q", name)
+		}
+
+		client := testAccProvider.Meta().(*ArmClient).groupsClient
+		ctx := testAccProvider.Meta().(*ArmClient).StopContext
+		resp, err := client.Get(ctx, rs.Primary.ID)
+
+		if err != nil {
+			if ar.ResponseWasNotFound(resp.Response) {
+				return fmt.Errorf("Bad: Azure AD Group %q does not exist", rs.Primary.ID)
+			}
+			return fmt.Errorf("Bad: Get on Azure AD groupsClient: %+v", err)
+		}
+
+		return nil
+	}
+}

--- a/azuread/provider.go
+++ b/azuread/provider.go
@@ -76,6 +76,7 @@ func Provider() terraform.ResourceProvider {
 		DataSourcesMap: map[string]*schema.Resource{
 			"azuread_application":       dataApplication(),
 			"azuread_service_principal": dataServicePrincipal(),
+			"azuread_group":             dataSourceArmActiveDirectoryGroup(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{

--- a/website/azuread.erb
+++ b/website/azuread.erb
@@ -55,6 +55,10 @@
                   <a href="/docs/providers/azuread/d/service_principal.html">azuread_service_principal</a>
                 </li>
 
+                <li<%= sidebar_current("docs-azuread-datasource-azuread-group") %>>
+                  <a href="/docs/providers/azuread/d/group.html">azuread_group</a>
+                </li>
+
               </ul>
             </li>
 

--- a/website/azuread.erb
+++ b/website/azuread.erb
@@ -51,7 +51,7 @@
                   <a href="/docs/providers/azuread/d/application.html">azuread_application</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azuread-datasource-azuread-application") %>>
+                <li<%= sidebar_current("docs-azuread-datasource-azuread-service-principal") %>>
                   <a href="/docs/providers/azuread/d/service_principal.html">azuread_service_principal</a>
                 </li>
 

--- a/website/docs/d/group.html.markdown
+++ b/website/docs/d/group.html.markdown
@@ -1,0 +1,46 @@
+---
+layout: "azuread"
+page_title: "Azure Active Directory: azuread_group"
+sidebar_current: "docs-azuread-datasource-azuread-group"
+description: |-
+  Gets information about an existing group defined in an Azure Active Directory.
+
+---
+
+# Data Source: azuread_group
+
+Gets information about an existing group defined in an Azure Active Directory.
+
+-> **NOTE:** If you're authenticating using a Service Principal then it must have permissions to ` Directory.Read.All` within the `Microsoft Graph` API. 
+
+## Example Usage (by Display Name)
+
+```hcl
+data "azuread_group" "test" {
+  display_name = "my-awesome-group"
+}
+```
+
+## Example Usage (by Object ID)
+
+```hcl
+data "azuread_group" "test" {
+  object_id = "00000000-0000-0000-0000-000000000000"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `object_id` - (Optional) The ID of the Azure AD Group.
+
+* `display_name` - (Optional) The Display Name of the Azure AD Group.
+
+-> **NOTE:** At least one of `display_name` or `object_id` must be specified.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The Object ID for the Group.


### PR DESCRIPTION
This is working code, but I am not sure how to configure the tests for public use. The tests work when I use a 

known group name (https://github.com/terraform-providers/terraform-provider-azuread/compare/master...lawrenae:feature/azuread_group?expand=1#diff-c5048a440fa3dd8fa2d9f626401b7642R65) 

or

known group object id (https://github.com/terraform-providers/terraform-provider-azuread/compare/master...lawrenae:feature/azuread_group?expand=1#diff-c5048a440fa3dd8fa2d9f626401b7642R74)

but I of course cant assume these to exist in everyone's tenant. Further, because there are no `resource`s for `azuread_group`, I dont *seem* to have a way to add one to AAD before running the test. 

I'd appreciate feedback on how to approach resolving this. 

Thanks!