### PR TITLE
New data source 'azuread_domains'

### DIFF
--- a/azuread/config.go
+++ b/azuread/config.go
@@ -29,6 +29,7 @@ type ArmClient struct {
 
 	// azure AD clients
 	applicationsClient      graphrbac.ApplicationsClient
+	domainsClient           graphrbac.DomainsClient
 	groupsClient            graphrbac.GroupsClient
 	servicePrincipalsClient graphrbac.ServicePrincipalsClient
 }
@@ -73,6 +74,9 @@ func getArmClient(authCfg *authentication.Config) (*ArmClient, error) {
 func (c *ArmClient) registerGraphRBACClients(endpoint, tenantID string, authorizer autorest.Authorizer) {
 	c.applicationsClient = graphrbac.NewApplicationsClientWithBaseURI(endpoint, tenantID)
 	configureClient(&c.applicationsClient.Client, authorizer)
+
+	c.domainsClient = graphrbac.NewDomainsClientWithBaseURI(endpoint, tenantID)
+	configureClient(&c.domainsClient.Client, authorizer)
 
 	c.groupsClient = graphrbac.NewGroupsClientWithBaseURI(endpoint, tenantID)
 	configureClient(&c.groupsClient.Client, authorizer)

--- a/azuread/data_domains.go
+++ b/azuread/data_domains.go
@@ -1,0 +1,99 @@
+package azuread
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataDomains() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceActiveDirectoryDomainsRead,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"tenant_domain_only": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"domains": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"domain_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"is_default": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"is_initial": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"is_verified": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceActiveDirectoryDomainsRead(d *schema.ResourceData, meta interface{}) error {
+	armClient := meta.(*ArmClient)
+	client := meta.(*ArmClient).domainsClient
+	ctx := meta.(*ArmClient).StopContext
+
+	tenantDomainOnly := false
+	if value, ok := d.GetOk("tenant_domain_only"); ok {
+		tenantDomainOnly = value.(bool)
+	}
+
+	results, err := client.List(ctx, "")
+	if err != nil {
+		return fmt.Errorf("Error listing Azure AD Domains: %+v", err)
+	}
+
+	//iterate across each domain and append it to slice
+	domains := make([]map[string]interface{}, 0)
+	for _, v := range *results.Value {
+		domain := make(map[string]interface{})
+
+		if tenantDomainOnly == true && v.AdditionalProperties["isInitial"].(bool) == false {
+			//we only want the tenant root domain, which is always the initial domain
+			//if this conditional matches, the current domain result should be skipped
+			log.Printf("[DEBUG] Domain %q skipped, as we only want the tenant root domain.", *v.Name)
+			continue
+		}
+
+		if v.Name != nil {
+			domain["domain_name"] = *v.Name
+		}
+		if v.AdditionalProperties["isInitial"] != nil {
+			domain["is_initial"] = v.AdditionalProperties["isInitial"].(bool)
+		}
+		if v.IsVerified != nil {
+			domain["is_verified"] = *v.IsVerified
+		}
+		if v.IsDefault != nil {
+			domain["is_default"] = *v.IsDefault
+		}
+
+		domains = append(domains, domain)
+	}
+
+	d.SetId("domains-" + armClient.tenantID)
+	if err = d.Set("domains", domains); err != nil {
+		return fmt.Errorf("Error setting `domains`: %+v", err)
+	}
+
+	return nil
+}

--- a/azuread/data_domains_test.go
+++ b/azuread/data_domains_test.go
@@ -1,0 +1,49 @@
+package azuread
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDataSourceAzureADDomains_basic(t *testing.T) {
+	dataSourceName := "data.azuread_domains.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: `data "azuread_domains" "test" {}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, "domains.0.domain_name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "domains.0.is_default"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "domains.0.is_initial"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "domains.0.is_verified"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceAzureADDomains_tenantDomainOnly(t *testing.T) {
+	dataSourceName := "data.azuread_domains.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: `data "azuread_domains" "test" {
+					tenant_domain_only = true
+				}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, "domains.0.domain_name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "domains.0.is_default"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "domains.0.is_initial"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "domains.0.is_verified"),
+				),
+			},
+		},
+	})
+}

--- a/azuread/provider.go
+++ b/azuread/provider.go
@@ -75,6 +75,7 @@ func Provider() terraform.ResourceProvider {
 
 		DataSourcesMap: map[string]*schema.Resource{
 			"azuread_application":       dataApplication(),
+			"azuread_domains":           dataDomains(),
 			"azuread_group":             dataGroup(),
 			"azuread_service_principal": dataServicePrincipal(),
 		},

--- a/website/azuread.erb
+++ b/website/azuread.erb
@@ -51,6 +51,10 @@
                   <a href="/docs/providers/azuread/d/application.html">azuread_application</a>
                 </li>
 
+                <li<%= sidebar_current("docs-azuread-datasource-azuread-domains") %>>
+                  <a href="/docs/providers/azuread/d/domains.html">azuread_domains</a>
+                </li>
+
                 <li<%= sidebar_current("docs-azuread-datasource-azuread-group") %>>
                   <a href="/docs/providers/azuread/d/group.html">azuread_group</a>
                 </li>

--- a/website/docs/d/domains.html.markdown
+++ b/website/docs/d/domains.html.markdown
@@ -1,0 +1,38 @@
+---
+layout: "azuread"
+page_title: "Azure Active Directory: azuread_domains"
+sidebar_current: "docs-azuread-datasource-azuread-domains"
+description: |-
+  Gets information about an existing Domains within Azure Active Directory.
+---
+
+# Data Source: azuread_domains
+
+Use this data source to access information about an existing Domains within Azure Active Directory.
+
+-> **NOTE:** If you're authenticating using a Service Principal then it must have permissions to `Directory.Read.All` within the `Windows Azure Active Directory` API.
+
+## Example Usage
+
+```hcl
+data "azuread_domains" "aad_domains" {}
+
+output "domains" {
+  value = "${data.azuread_domains.aad_domains.domains}"
+}
+```
+
+## Argument Reference
+
+* `tenant_domain_only` - (Optional) Set to `true` if only the Azure AD tenant root domain should be returned. Defaults to `false`.
+
+## Attributes Reference
+
+* `domains` - One or more `domain` blocks as defined below.
+
+The `domain` block contains:
+
+* `domain_name` - The name of the domain.
+* `is_default` - `True` if this is the default domain that is used for user creation.
+* `is_initial` - `True` if this is the initial domain created by Azure Activie Directory.
+* `is_verified` - `True` if the domain has completed domain ownership verification.


### PR DESCRIPTION
This PR adds a new data source for Domains registered in Azure AD.

- [x] New data source 'azuread_domains'
- [x] Add markdown documentation
- [x] Add tests

## Example Usage

```hcl

// This gets all domains currently registered in Azure AD
data "azuread_domains" "my_domains" {}

// This will return only the tenant root domain (foo.onmicrosoft.com)
data "azuread_domains" "my_root_domain" {
 tenant_domain_only = true
}

```

## Example Output
```json
domains = [
    {
        domain_name = hashicorp.onmicrosoft.com,
        is_default = 1,
        is_initial = 1,
        is_verified = 1
    }
]
```

## Use cases

* This will be helpful to create objects where the user principal name is required and not known during runtime (testing for example)