### PR TITLE
Allow settings group_membership_claims on ad application

### DIFF
--- a/azuread/helpers/suppress/string.go
+++ b/azuread/helpers/suppress/string.go
@@ -1,0 +1,11 @@
+package suppress
+
+import (
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func CaseDifference(_, old, new string, _ *schema.ResourceData) bool {
+	return strings.EqualFold(old, new)
+}

--- a/azuread/helpers/suppress/string_test.go
+++ b/azuread/helpers/suppress/string_test.go
@@ -1,0 +1,51 @@
+package suppress
+
+import "testing"
+
+func TestCaseDifference(t *testing.T) {
+	cases := []struct {
+		Name     string
+		StringA  string
+		StringB  string
+		Suppress bool
+	}{
+		{
+			Name:     "empty",
+			StringA:  "",
+			StringB:  "",
+			Suppress: true,
+		},
+		{
+			Name:     "empty vs text",
+			StringA:  "ye old text",
+			StringB:  "",
+			Suppress: false,
+		},
+		{
+			Name:     "different text",
+			StringA:  "ye old text?",
+			StringB:  "ye different text",
+			Suppress: false,
+		},
+		{
+			Name:     "same text",
+			StringA:  "ye same text!",
+			StringB:  "ye same text!",
+			Suppress: true,
+		},
+		{
+			Name:     "same text different case",
+			StringA:  "ye old text?",
+			StringB:  "Ye OLD texT?",
+			Suppress: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			if CaseDifference("test", tc.StringA, tc.StringB, nil) != tc.Suppress {
+				t.Fatalf("Expected CaseDifference to return %t for '%q' == '%q'", tc.Suppress, tc.StringA, tc.StringB)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Set the groupMembershipClaims into AdditionalProperties[1]. This is an
unvalidated map that can be used to set arbitrary manifest entries.

This is kind of new for terraform however in this case the inputs are
well documented[2] and can be validated.

This imports the suppress case difference in strings helper from the
azuread provider.

[1] https://godoc.org/github.com/Azure/azure-sdk-for-go/services/graphrbac/1.6/graphrbac#ApplicationCreateParameters
[2] https://docs.microsoft.com/en-us/azure/active-directory/develop/reference-app-manifest