### PR TITLE
linting: enable goimports

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,7 @@ linters:
     - deadcode
     - errcheck
     - gofmt
+    - goimports
     - gosimple
     - govet
     - ineffassign


### PR DESCRIPTION
Was not enabled during the switch to golangci due to a bug in the version of goimports they used. As it's been fixed re-enabling it.
