### PR TITLE
New resource 'azuread_group_member'

### DIFF
--- a/azuread/provider.go
+++ b/azuread/provider.go
@@ -84,6 +84,7 @@ func Provider() terraform.ResourceProvider {
 		ResourcesMap: map[string]*schema.Resource{
 			"azuread_application":                resourceApplication(),
 			"azuread_group":                      resourceGroup(),
+			"azuread_group_member":               resourceGroupMember(),
 			"azuread_service_principal":          resourceServicePrincipal(),
 			"azuread_service_principal_password": resourceServicePrincipalPassword(),
 			"azuread_user":                       resourceUser(),

--- a/azuread/resource_group_member.go
+++ b/azuread/resource_group_member.go
@@ -1,0 +1,156 @@
+package azuread
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/services/graphrbac/1.6/graphrbac"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azuread/azuread/helpers/ar"
+	"github.com/terraform-providers/terraform-provider-azuread/azuread/helpers/validate"
+)
+
+func resourceGroupMember() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceGroupMemberCreate,
+		Read:   resourceGroupMemberRead,
+		Delete: resourceGroupMemberDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"group_object_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.UUID,
+			},
+			"member_object_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.UUID,
+			},
+		},
+	}
+}
+
+func resourceGroupMemberCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).groupsClient
+	ctx := meta.(*ArmClient).StopContext
+
+	groupID := d.Get("group_object_id").(string)
+	memberID := d.Get("member_object_id").(string)
+	tenantID := client.TenantID
+
+	memberGraphURL := fmt.Sprintf("https://graph.windows.net/%s/directoryObjects/%s", tenantID, memberID)
+
+	properties := graphrbac.GroupAddMemberParameters{
+		URL: &memberGraphURL,
+	}
+
+	_, err := client.AddMember(ctx, groupID, properties)
+	if err != nil {
+		return err
+	}
+
+	id := fmt.Sprintf("%s/%s", groupID, memberID)
+	d.SetId(id)
+
+	return resourceGroupMemberRead(d, meta)
+}
+
+func resourceGroupMemberRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).groupsClient
+	ctx := meta.(*ArmClient).StopContext
+
+	id := strings.Split(d.Id(), "/")
+	if len(id) != 2 {
+		return fmt.Errorf("ID should be in the format {groupObjectId}/{memberObjectId} - but got %q", d.Id())
+	}
+
+	groupID := id[0]
+	memberID := id[1]
+
+	members, err := client.GetGroupMembersComplete(ctx, groupID)
+	if err != nil {
+		return fmt.Errorf("Error retrieving Azure AD Group members (groupObjectId: %q): %+v", groupID, err)
+	}
+
+	var memberObjectID string
+	for members.NotDone() {
+		// possible members are users, groups or service principals
+		// we try to 'cast' each result as the correspondig type and diff
+		// if we found the object we're looking for
+		user, _ := members.Value().AsUser()
+		if user != nil {
+			if *user.ObjectID == memberID {
+				memberObjectID = *user.ObjectID
+				// we successfully found the directory object we're looking for, we can stop looping
+				// through the results
+				break
+			}
+		}
+
+		group, _ := members.Value().AsADGroup()
+		if group != nil {
+			if *group.ObjectID == memberID {
+				memberObjectID = *group.ObjectID
+				// we successfully found the directory object we're looking for, we can stop looping
+				// through the results
+				break
+			}
+		}
+
+		servicePrincipal, _ := members.Value().AsServicePrincipal()
+		if servicePrincipal != nil {
+			if *servicePrincipal.ObjectID == memberID {
+				memberObjectID = *servicePrincipal.ObjectID
+				// we successfully found the directory object we're looking for, we can stop looping
+				// through the results
+				break
+			}
+		}
+
+		err = members.NextWithContext(ctx)
+		if err != nil {
+			return fmt.Errorf("Error listing Azure AD Group Members: %s", err)
+		}
+	}
+
+	if memberObjectID == "" {
+		log.Printf("[DEBUG] Azure AD Group Member was not found (groupObjectId:%q / memberObjectId:%q ) - removing from state!", groupID, memberID)
+		d.SetId("")
+		return fmt.Errorf("Azure AD Group Member not found - groupObjectId:%q / memberObjectId:%q", groupID, memberID)
+	}
+
+	d.Set("group_object_id", groupID)
+	d.Set("member_object_id", memberObjectID)
+
+	return nil
+}
+
+func resourceGroupMemberDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).groupsClient
+	ctx := meta.(*ArmClient).StopContext
+
+	id := strings.Split(d.Id(), "/")
+	if len(id) != 2 {
+		return fmt.Errorf("ID should be in the format {groupObjectId}/{memberObjectId} - but got %q", d.Id())
+	}
+
+	groupID := id[0]
+	memberID := id[1]
+
+	resp, err := client.RemoveMember(ctx, groupID, memberID)
+
+	if err != nil {
+		if !ar.ResponseWasNotFound(resp) {
+			return fmt.Errorf("Error removing Member (memberObjectId: %q) from Azure AD Group (groupObjectId: %q): %+v", memberID, groupID, err)
+		}
+	}
+
+	return nil
+}

--- a/azuread/resource_group_member_test.go
+++ b/azuread/resource_group_member_test.go
@@ -1,0 +1,224 @@
+package azuread
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/terraform-providers/terraform-provider-azuread/azuread/helpers/ar"
+)
+
+func TestAccAzureADGroupMember_User(t *testing.T) {
+	resourceName := "azuread_group_member.test"
+	id := acctest.RandStringFromCharSet(7, acctest.CharSetAlphaNum)
+	password := id + "p@$$wR2"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureADGroupMemberDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureADGroupMember_User(id, password),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "group_object_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "member_object_id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAzureADGroupMember_Group(t *testing.T) {
+	resourceName := "azuread_group_member.test"
+	id := acctest.RandStringFromCharSet(7, acctest.CharSetAlphaNum)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureADGroupMemberDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureADGroupMember_Group(id),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "group_object_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "member_object_id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAzureADGroupMember_ServicePrincipal(t *testing.T) {
+	resourceName := "azuread_group_member.test"
+	id := acctest.RandStringFromCharSet(7, acctest.CharSetAlphaNum)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureADGroupMemberDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureADGroupMember_ServicePrincipal(id),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "group_object_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "member_object_id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testCheckAzureADGroupMemberDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "azuread_group_member" {
+			continue
+		}
+
+		client := testAccProvider.Meta().(*ArmClient).groupsClient
+		ctx := testAccProvider.Meta().(*ArmClient).StopContext
+
+		groupID := rs.Primary.Attributes["group_object_id"]
+		memberID := rs.Primary.Attributes["member_object_id"]
+
+		members, err := client.GetGroupMembersComplete(ctx, groupID)
+		if err != nil {
+			if ar.ResponseWasNotFound(members.Response().Response) {
+				return nil
+			}
+
+			return err
+		}
+
+		var memberObjectID string
+		for members.NotDone() {
+			// possible members are users, groups or service principals
+			// we try to 'cast' each result as the correspondig type and diff
+			// if we found the object we're looking for
+			user, _ := members.Value().AsUser()
+			if user != nil {
+				if *user.ObjectID == memberID {
+					memberObjectID = *user.ObjectID
+					// we successfully found the directory object we're looking for, we can stop looping
+					// through the results
+					break
+				}
+			}
+
+			group, _ := members.Value().AsADGroup()
+			if group != nil {
+				if *group.ObjectID == memberID {
+					memberObjectID = *group.ObjectID
+					// we successfully found the directory object we're looking for, we can stop looping
+					// through the results
+					break
+				}
+			}
+
+			servicePrincipal, _ := members.Value().AsServicePrincipal()
+			if servicePrincipal != nil {
+				if *servicePrincipal.ObjectID == memberID {
+					memberObjectID = *servicePrincipal.ObjectID
+					// we successfully found the directory object we're looking for, we can stop looping
+					// through the results
+					break
+				}
+			}
+
+			err = members.NextWithContext(ctx)
+			if err != nil {
+				return fmt.Errorf("Error listing Azure AD Group Members: %s", err)
+			}
+		}
+
+		if memberObjectID != "" {
+			return fmt.Errorf("Azure AD group member still exists:\n%#v", memberObjectID)
+		}
+	}
+
+	return nil
+}
+
+func testAccAzureADGroupMember_User(id string, password string) string {
+	return fmt.Sprintf(`
+
+data "azuread_domains" "tenant_domain" {
+	only_initial = true
+}
+
+resource "azuread_user" "test" {
+	user_principal_name   = "acctestA%[1]s@${data.azuread_domains.tenant_domain.domains.0.domain_name}"
+	display_name          = "acctestA%[1]s"
+	password              = "%[2]s"
+}
+	
+resource "azuread_group" "test" {
+	name = "acctest%[1]s"
+}
+
+resource "azuread_group_member" "test" {
+	group_object_id 	= "${azuread_group.test.id}"
+	member_object_id 	= "${azuread_user.test.id}"
+}
+
+`, id, password)
+}
+
+func testAccAzureADGroupMember_Group(id string) string {
+	return fmt.Sprintf(`
+	
+resource "azuread_group" "testA" {
+	name = "acctestA%[1]s"
+}
+
+resource "azuread_group" "testB" {
+	name = "acctestB%[1]s"
+}
+
+resource "azuread_group_member" "test" {
+	group_object_id 	= "${azuread_group.testA.id}"
+	member_object_id 	= "${azuread_group.testB.id}"
+}
+
+`, id)
+}
+
+func testAccAzureADGroupMember_ServicePrincipal(id string) string {
+	return fmt.Sprintf(`
+
+resource "azuread_application" "test" {
+	name = "acctest%[1]s"
+}
+
+resource "azuread_service_principal" "test" {
+	application_id = "${azuread_application.test.application_id}"
+}
+
+resource "azuread_group" "test" {
+	name = "acctestA%[1]s"
+}
+
+resource "azuread_group_member" "test" {
+	group_object_id 	= "${azuread_group.test.id}"
+	member_object_id 	= "${azuread_service_principal.test.id}"
+}
+
+`, id)
+}

--- a/website/azuread.erb
+++ b/website/azuread.erb
@@ -82,6 +82,10 @@
                   <a href="/docs/providers/azuread/r/group.html">azuread_group</a>
                 </li>
 
+                <li<%= sidebar_current("docs-azuread-resource-azuread-group-member") %>>
+                  <a href="/docs/providers/azuread/r/group_member.html">azuread_group_member</a>
+                </li>
+
                 <li<%= sidebar_current("docs-azuread-resource-azuread-service-principal-x") %>>
                   <a href="/docs/providers/azuread/r/service_principal.html">azuread_service_principal</a>
                 </li>

--- a/website/docs/r/group_member.markdown
+++ b/website/docs/r/group_member.markdown
@@ -1,0 +1,55 @@
+---
+layout: "azuread"
+page_title: "Azure Active Directory: azuread_group_member"
+sidebar_current: "docs-azuread-resource-azuread-group-member"
+description: |-
+  Manages a Group Membership within Azure Active Directory.
+
+---
+
+# azuread_group_member
+
+Manages a Group Membership within Azure Active Directory.
+
+## Example Usage
+
+```hcl
+
+data "azuread_user" "my_user" {
+  user_principal_name = "johndoe@hashicorp.com"
+}
+
+resource "azuread_group" "my_group" {
+  name = "my_group"
+}
+
+resource "azuread_group_member" "test" {
+  group_object_id   = "${azuread_group.my_group.id}"
+  member_object_id  = "${data.azuread_user.my_user.id}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `group_object_id` - (Required) The Object ID of the Azure AD Group you want to add the Member to.
+* `member_object_id` - (Required) The Object ID of the Azure AD Object you want to add as a Member to the Group. Supported Object types are Users, Groups or Service Principals.
+
+-> **NOTE:** The Member object has to be present in your Azure Active Directory, either as a Member or a Guest.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the Azure AD Group Member.
+
+## Import
+
+Azure Active Directory Group Members can be imported using the `object id`, e.g.
+
+```shell
+terraform import azuread_group_member.test 00000000-0000-0000-0000-000000000000/11111111-1111-1111-1111-111111111111
+```
+
+-> **NOTE:** This ID format is unique to Terraform and is composed of the Azure AD Group Object ID and the target Member Object ID in the format `{GroupObjectID}/{MemberObjectID}`.


### PR DESCRIPTION
This adds a new resource to manage Azure AD Group Membership with Terraform.

- [x] New resource 'azuread_group_member'
- [x] Add tests
- [x] Add documentation

## Example Usage

```hcl

data "azuread_user" "my_user" {
  user_principal_name = "johndoe@hashicorp.com"
}

resource "azuread_group" "my_group" {
  name = "my_group"
}

resource "azuread_group_member" "test" {
  group_object_id   = "${azuread_group.my_group.id}"
  member_object_id  = "${data.azuread_user.my_user.id}"
}
```

## Argument Reference

The following arguments are supported:

* `group_object_id` - (Required) The Object ID of the Azure AD Group you want to add the Member to.
* `member_object_id` - (Required) The Object ID of the Azure AD Object you want to add as a Member to the Group. Supported Object types are Users, Groups or Service Principals.