### PR TITLE
Added appId output to the documentation - esp. important for AKS

### DIFF
--- a/website/docs/r/service_principal.html.markdown
+++ b/website/docs/r/service_principal.html.markdown
@@ -44,7 +44,9 @@ The following arguments are supported:
 
 The following attributes are exported:
 
-* `id` - The Object ID for the Service Principal.
+* `id` - The Object ID (internal ID) for the Service Principal.
+
+* `application_id` - The Application ID (appId) for the Service Principal.
 
 * `display_name` - The Display Name of the Azure Active Directory Application associated with this Service Principal.
 


### PR DESCRIPTION
appId was missing in the Service Principal creation output, added it.