### PR TITLE
data.azuread_[group|user]: add lookup by object_id

### DIFF
--- a/azuread/data_application.go
+++ b/azuread/data_application.go
@@ -167,15 +167,15 @@ func dataApplicationRead(d *schema.ResourceData, meta interface{}) error {
 
 	var app graphrbac.Application
 
-	if oId, ok := d.GetOk("object_id"); ok {
+	if oId, ok := d.Get("object_id").(string); ok && oId != "" {
 		// use the object_id to find the Azure AD application
-		resp, err := client.Get(ctx, oId.(string))
+		resp, err := client.Get(ctx, oId)
 		if err != nil {
 			if ar.ResponseWasNotFound(resp.Response) {
-				return fmt.Errorf("Error: AzureAD Application with ID %q was not found", oId.(string))
+				return fmt.Errorf("Error: AzureAD Application with ID %q was not found", oId)
 			}
 
-			return fmt.Errorf("Error making Read request on AzureAD Application with ID %q: %+v", oId.(string), err)
+			return fmt.Errorf("Error making Read request on AzureAD Application with ID %q: %+v", oId, err)
 		}
 
 		app = resp

--- a/azuread/data_domains.go
+++ b/azuread/data_domains.go
@@ -74,7 +74,7 @@ func dataSourceActiveDirectoryDomainsRead(d *schema.ResourceData, meta interface
 		return fmt.Errorf("Error listing Azure AD Domains: %+v", err)
 	}
 
-	d.SetId("domains-" + tenantId)
+	d.SetId("domains-" + tenantId) // todo this should be more unique
 
 	domains := flattenDomains(results.Value, includeUnverified, onlyDefault, onlyInitial)
 	if len(domains) == 0 {

--- a/azuread/data_group.go
+++ b/azuread/data_group.go
@@ -42,19 +42,19 @@ func dataSourceActiveDirectoryGroupRead(d *schema.ResourceData, meta interface{}
 
 	var group graphrbac.ADGroup
 
-	if oId, ok := d.GetOk("object_id"); ok {
+	if oId, ok := d.Get("object_id").(string); ok && oId != "" {
 		// use the object_id to find the Azure AD application
-		resp, err := client.Get(ctx, oId.(string))
+		resp, err := client.Get(ctx, oId)
 		if err != nil {
 			if ar.ResponseWasNotFound(resp.Response) {
-				return fmt.Errorf("Error: AzureAD Group with ID %q was not found", oId.(string))
+				return fmt.Errorf("Error: AzureAD Group with ID %q was not found", oId)
 			}
 
-			return fmt.Errorf("Error making Read request on AzureAD Group with ID %q: %+v", oId.(string), err)
+			return fmt.Errorf("Error making Read request on AzureAD Group with ID %q: %+v", oId, err)
 		}
 
 		group = resp
-	} else if name, ok := d.Get("name").(string); ok {
+	} else if name, ok := d.Get("name").(string); ok && name != "" {
 		filter := fmt.Sprintf("displayName eq '%s'", name)
 
 		resp, err := client.ListComplete(ctx, filter)

--- a/azuread/data_group.go
+++ b/azuread/data_group.go
@@ -2,10 +2,10 @@ package azuread
 
 import (
 	"fmt"
-	"log"
 
 	"github.com/Azure/azure-sdk-for-go/services/graphrbac/1.6/graphrbac"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azuread/azuread/helpers/ar"
 	"github.com/terraform-providers/terraform-provider-azuread/azuread/helpers/validate"
 )
 
@@ -17,10 +17,20 @@ func dataGroup() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"object_id": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ValidateFunc:  validate.UUID,
+				ConflictsWith: []string{"name"},
+			},
+
 			"name": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validate.NoEmptyStrings,
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ValidateFunc:  validate.NoEmptyStrings,
+				ConflictsWith: []string{"object_id"},
 			},
 		},
 	}
@@ -30,40 +40,56 @@ func dataSourceActiveDirectoryGroupRead(d *schema.ResourceData, meta interface{}
 	client := meta.(*ArmClient).groupsClient
 	ctx := meta.(*ArmClient).StopContext
 
-	var groupObj *graphrbac.ADGroup
+	var group graphrbac.ADGroup
 
-	// use the name to find the Azure AD group
-	name := d.Get("name").(string)
-	filter := fmt.Sprintf("displayName eq '%s'", name)
-	log.Printf("[DEBUG] Using filter %q", filter)
+	if oId, ok := d.GetOk("object_id"); ok {
+		// use the object_id to find the Azure AD application
+		resp, err := client.Get(ctx, oId.(string))
+		if err != nil {
+			if ar.ResponseWasNotFound(resp.Response) {
+				return fmt.Errorf("Error: AzureAD Group with ID %q was not found", oId.(string))
+			}
 
-	resp, err := client.ListComplete(ctx, filter)
-	if err != nil {
-		return fmt.Errorf("Error listing Azure AD groups: %+v", err)
-	}
-
-	for _, v := range *resp.Response().Value {
-		if v.DisplayName == nil {
-			continue
+			return fmt.Errorf("Error making Read request on AzureAD Group with ID %q: %+v", oId.(string), err)
 		}
 
-		if *v.DisplayName == name {
-			log.Printf("[DEBUG] %q (API result) matches %q (given value)", *v.DisplayName, name)
-			groupObj = &v
-			break
-		} else {
-			log.Printf("[DEBUG] %q (API result) does not match %q (given value)", *v.DisplayName, name)
+		group = resp
+	} else if name, ok := d.Get("name").(string); ok {
+		filter := fmt.Sprintf("displayName eq '%s'", name)
+
+		resp, err := client.ListComplete(ctx, filter)
+		if err != nil {
+			return fmt.Errorf("Error listing Azure AD Groups for filter %q: %+v", filter, err)
 		}
+
+		values := resp.Response().Value
+		if values == nil {
+			return fmt.Errorf("nil values for AD Groups matching %q", filter)
+		}
+		if len(*values) == 0 {
+			return fmt.Errorf("Found no AD Groups matching %q", filter)
+		}
+		if len(*values) > 2 {
+			return fmt.Errorf("Found multiple AD Groups matching %q", filter)
+		}
+
+		group = (*values)[0]
+		if group.DisplayName == nil {
+			return fmt.Errorf("nil DisplayName for AD Groups matching %q", filter)
+		}
+		if *group.DisplayName != name {
+			return fmt.Errorf("displayname for AD Groups matching %q does is does not match(%q!=%q)", filter, *group.DisplayName, name)
+		}
+	} else {
+		return fmt.Errorf("one of `object_id` or `name` must be supplied")
 	}
 
-	if groupObj == nil {
-		return fmt.Errorf("Couldn't locate a Azure AD group with a name of %q", name)
-	}
-
-	if groupObj.ObjectID == nil {
+	if group.ObjectID == nil {
 		return fmt.Errorf("Group objectId is nil")
 	}
-	d.SetId(*groupObj.ObjectID)
+	d.SetId(*group.ObjectID)
 
+	d.Set("object_id", group.ObjectID)
+	d.Set("name", group.DisplayName)
 	return nil
 }

--- a/azuread/data_group_test.go
+++ b/azuread/data_group_test.go
@@ -4,17 +4,13 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/go-uuid"
+	"github.com/google/uuid"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
 func TestAccDataSourceAzureADGroup_byName(t *testing.T) {
 	dataSourceName := "data.azuread_group.test"
-	id, err := uuid.GenerateUUID()
-	if err != nil {
-		t.Fatal(err)
-	}
-	config := testAccDataSourceAzureADGroup_name(id)
+	id := uuid.New().String()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -25,7 +21,30 @@ func TestAccDataSourceAzureADGroup_byName(t *testing.T) {
 				Config: testAccAzureADGroup(id),
 			},
 			{
-				Config: config,
+				Config: testAccDataSourceAzureADGroup_name(id),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureADGroupExists(dataSourceName),
+					resource.TestCheckResourceAttr(dataSourceName, "name", fmt.Sprintf("acctest%s", id)),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceAzureADGroup_byObjectId(t *testing.T) {
+	dataSourceName := "data.azuread_group.test"
+	id := uuid.New().String()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureADGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureADGroup(id),
+			},
+			{
+				Config: testAccDataSourceAzureADGroup_objectId(id),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureADGroupExists(dataSourceName),
 					resource.TestCheckResourceAttr(dataSourceName, "name", fmt.Sprintf("acctest%s", id)),
@@ -36,12 +55,21 @@ func TestAccDataSourceAzureADGroup_byName(t *testing.T) {
 }
 
 func testAccDataSourceAzureADGroup_name(id string) string {
-	template := testAccAzureADGroup(id)
 	return fmt.Sprintf(`
 %s
 
 data "azuread_group" "test" {
   name = "${azuread_group.test.name}"
 }
-`, template)
+`, testAccAzureADGroup(id))
+}
+
+func testAccDataSourceAzureADGroup_objectId(id string) string {
+	return fmt.Sprintf(`
+%s
+
+data "azuread_group" "test" {
+  object_id = "${azuread_group.test.id}"
+}
+`, testAccAzureADGroup(id))
 }

--- a/azuread/data_user.go
+++ b/azuread/data_user.go
@@ -62,19 +62,20 @@ func dataSourceUserRead(d *schema.ResourceData, meta interface{}) error {
 
 	var user graphrbac.User
 
-	if upn, ok := d.GetOk("user_principal_name"); ok {
+	if upn, ok := d.Get("user_principal_name").(string); ok && upn != "" {
+
 		// use the object_id to find the Azure AD application
-		resp, err := client.Get(ctx, upn.(string))
+		resp, err := client.Get(ctx, upn)
 		if err != nil {
 			if ar.ResponseWasNotFound(resp.Response) {
-				return fmt.Errorf("Error: AzureAD User with ID %q was not found", upn.(string))
+				return fmt.Errorf("Error: AzureAD User with ID %q was not found", upn)
 			}
 
-			return fmt.Errorf("Error making Read request on AzureAD User with ID %q: %+v", upn.(string), err)
+			return fmt.Errorf("Error making Read request on AzureAD User with ID %q: %+v", upn, err)
 		}
 
 		user = resp
-	} else if oId, ok := d.Get("object_id").(string); ok {
+	} else if oId, ok := d.Get("object_id").(string); ok && oId != "" {
 		filter := fmt.Sprintf("objectId eq '%s'", oId)
 
 		resp, err := client.ListComplete(ctx, filter)

--- a/azuread/data_user.go
+++ b/azuread/data_user.go
@@ -98,8 +98,8 @@ func dataSourceUserRead(d *schema.ResourceData, meta interface{}) error {
 		if user.DisplayName == nil {
 			return fmt.Errorf("nil DisplayName for AD Users matching %q", filter)
 		}
-		if *user.DisplayName != oId {
-			return fmt.Errorf("displayname for AD Users matching %q does is does not match(%q!=%q)", filter, *user.DisplayName, oId)
+		if *user.ObjectID != oId {
+			return fmt.Errorf("objectID for AD Users matching %q does is does not match(%q!=%q)", filter, *user.ObjectID, oId)
 		}
 	} else {
 		return fmt.Errorf("one of `object_id` or `user_principal_name` must be supplied")

--- a/azuread/data_user_test.go
+++ b/azuread/data_user_test.go
@@ -31,14 +31,44 @@ func TestAccDataSourceAzureADUser_byUserPrincipalName(t *testing.T) {
 	})
 }
 
-func testAccAzureADUserDataSource_byUserPrincipalName(id, password string) string {
-	template := testAccADUser_basic(id, password)
-	return fmt.Sprintf(`
+func TestAccDataSourceAzureADUser_byObjectId(t *testing.T) {
+	dataSourceName := "data.azuread_user.test"
+	id := acctest.RandStringFromCharSet(7, acctest.CharSetAlphaNum)
+	password := id + "p@$$wR2"
 
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureADUserDataSource_byObjectId(id, password),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, "user_principal_name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "account_enabled"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "display_name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "mail_nickname"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAzureADUserDataSource_byUserPrincipalName(id, password string) string {
+	return fmt.Sprintf(`
 %s
 
 data "azuread_user" "test" {
 	user_principal_name = "${azuread_user.test.user_principal_name}"
 }
-`, template)
+`, testAccADUser_basic(id, password))
+}
+
+func testAccAzureADUserDataSource_byObjectId(id, password string) string {
+	return fmt.Sprintf(`
+%s
+
+data "azuread_user" "test" {
+	user_principal_name = "${azuread_user.test.user_principal_name}"
+}
+`, testAccADUser_basic(id, password))
 }

--- a/azuread/data_user_test.go
+++ b/azuread/data_user_test.go
@@ -68,7 +68,7 @@ func testAccAzureADUserDataSource_byObjectId(id, password string) string {
 %s
 
 data "azuread_user" "test" {
-	user_principal_name = "${azuread_user.test.user_principal_name}"
+	object_id = "${azuread_user.test.id}"
 }
 `, testAccADUser_basic(id, password))
 }

--- a/website/docs/d/group.html.markdown
+++ b/website/docs/d/group.html.markdown
@@ -25,9 +25,11 @@ data "azuread_group" "test_group" {
 
 The following arguments are supported:
 
-* `name` - (Required) The Name of the Azure AD Group we want to lookup.
+* `name` - (Optional) The Name of the AD Group we want to lookup.
 
-~> **WARNING:** `name` is not unique within Azure Active Directory. The data source will only return the first Group found.
+* `object_id` - (Optional) Specifies the Object ID of the AD Group within Azure Active Directory.
+
+-> **NOTE:** Either a `name` or an `object_id` must be specified.
 
 ## Attributes Reference
 

--- a/website/docs/d/service_principal.html.markdown
+++ b/website/docs/d/service_principal.html.markdown
@@ -41,7 +41,7 @@ data "azuread_service_principal" "test" {
 
 The following arguments are supported:
 
-* `application_id` - (Optional) The ID of the Azure AD Application for which to create a Service Principal.
+* `application_id` - (Optional) The ID of the Azure AD Application.
 
 * `object_id` - (Optional) The ID of the Azure AD Service Principal.
 

--- a/website/docs/d/user.html.markdown
+++ b/website/docs/d/user.html.markdown
@@ -27,6 +27,10 @@ The following arguments are supported:
 
 * `user_principal_name` - (Required) The User Principal Name of the Azure AD User.
 
+* `object_id` - (Optional) Specifies the Object ID of the Application within Azure Active Directory.
+
+-> **NOTE:** Either a `user_principal_name` or an `object_id` must be specified.
+
 ## Attributes Reference
 
 The following attributes are exported:


### PR DESCRIPTION
This allows looking up by object_id.

As well fixes a bug where id there are multiple groups or users found for a given name it will now error instead of only returning the first.