### PR TITLE
azuread_application_password: deprecate application_id in favour of application_object_id

### DIFF
--- a/azuread/data_service_principal.go
+++ b/azuread/data_service_principal.go
@@ -3,11 +3,11 @@ package azuread
 import (
 	"fmt"
 
-	"github.com/terraform-providers/terraform-provider-azuread/azuread/helpers/ar"
-	"github.com/terraform-providers/terraform-provider-azuread/azuread/helpers/validate"
-
 	"github.com/Azure/azure-sdk-for-go/services/graphrbac/1.6/graphrbac"
 	"github.com/hashicorp/terraform/helper/schema"
+
+	"github.com/terraform-providers/terraform-provider-azuread/azuread/helpers/ar"
+	"github.com/terraform-providers/terraform-provider-azuread/azuread/helpers/validate"
 )
 
 func dataServicePrincipal() *schema.Resource {

--- a/azuread/data_service_principal.go
+++ b/azuread/data_service_principal.go
@@ -3,14 +3,11 @@ package azuread
 import (
 	"fmt"
 
-	"github.com/terraform-providers/terraform-provider-azuread/azuread/helpers/ar"
-	"github.com/terraform-providers/terraform-provider-azuread/azuread/helpers/graph"
-	"github.com/terraform-providers/terraform-provider-azuread/azuread/helpers/validate"
-
 	"github.com/Azure/azure-sdk-for-go/services/graphrbac/1.6/graphrbac"
 	"github.com/hashicorp/terraform/helper/schema"
 
 	"github.com/terraform-providers/terraform-provider-azuread/azuread/helpers/ar"
+	"github.com/terraform-providers/terraform-provider-azuread/azuread/helpers/graph"
 	"github.com/terraform-providers/terraform-provider-azuread/azuread/helpers/validate"
 )
 

--- a/azuread/data_user_test.go
+++ b/azuread/data_user_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
-
 	"github.com/hashicorp/terraform/helper/resource"
 )
 

--- a/azuread/resource_application.go
+++ b/azuread/resource_application.go
@@ -5,7 +5,6 @@ import (
 	"log"
 
 	"github.com/Azure/azure-sdk-for-go/services/graphrbac/1.6/graphrbac"
-
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
 

--- a/azuread/resource_application_password.go
+++ b/azuread/resource_application_password.go
@@ -99,7 +99,7 @@ func resourceApplicationPasswordCreate(d *schema.ResourceData, meta interface{})
 		objectId = d.Get("application_id").(string)
 	}
 	if objectId == "" {
-		return fmt.Errorf("one of `application_object_id` or `application_id` must be specifed")
+		return fmt.Errorf("one of `application_object_id` or `application_id` must be specified")
 	}
 
 	cred, err := graph.PasswordCredentialForResource(d)

--- a/azuread/resource_service_principal.go
+++ b/azuread/resource_service_principal.go
@@ -39,12 +39,12 @@ func resourceServicePrincipal() *schema.Resource {
 				Computed: true,
 			},
 
-			"oauth2_permissions": graph.SchemaOauth2Permissions(),
-
 			"object_id": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+
+			"oauth2_permissions": graph.SchemaOauth2Permissions(),
 
 			"tags": {
 				Type:     schema.TypeSet,
@@ -113,6 +113,7 @@ func resourceServicePrincipalRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("application_id", app.AppID)
 	d.Set("display_name", app.DisplayName)
 	d.Set("object_id", app.ObjectID)
+
 	// tags doesn't exist as a property, so extract it
 	if err := d.Set("tags", app.Tags); err != nil {
 		return fmt.Errorf("Error setting `tags`: %+v", err)

--- a/azuread/resource_service_principal_password_test.go
+++ b/azuread/resource_service_principal_password_test.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/terraform-providers/terraform-provider-azuread/azuread/helpers/ar"
-	"github.com/terraform-providers/terraform-provider-azuread/azuread/helpers/graph"
-
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
+
+	"github.com/terraform-providers/terraform-provider-azuread/azuread/helpers/ar"
+	"github.com/terraform-providers/terraform-provider-azuread/azuread/helpers/graph"
 )
 
 func testCheckADServicePrincipalPasswordExists(name string) resource.TestCheckFunc { //nolint unparam

--- a/azuread/resource_service_principal_test.go
+++ b/azuread/resource_service_principal_test.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/terraform-providers/terraform-provider-azuread/azuread/helpers/ar"
-
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
+
+	"github.com/terraform-providers/terraform-provider-azuread/azuread/helpers/ar"
 )
 
 func TestAccAzureADServicePrincipal_basic(t *testing.T) {

--- a/azuread/resource_user_test.go
+++ b/azuread/resource_user_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
-
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 

--- a/website/docs/r/application_password.html.markdown
+++ b/website/docs/r/application_password.html.markdown
@@ -36,7 +36,7 @@ resource "azuread_application_password" "example" {
 
 The following arguments are supported:
 
-* `object_id` - (Required) The Object ID of the Application for which this password should be created. Changing this field forces a new resource to be created.
+* `application_object_id` - (Required) The Object ID of the Application for which this password should be created. Changing this field forces a new resource to be created.
 
 * `value` - (Required) The Password for this Application .
 


### PR DESCRIPTION
fixes #106 

given there is both `application.object_id` and `application.application_id` this should bring some clarity and hopefully prevent confusion.