### PR TITLE
capture current hashibot config

### DIFF
--- a/.hashibot.hcl
+++ b/.hashibot.hcl
@@ -1,6 +1,6 @@
 queued_behavior "release_commenter" "releases" {
-    repo_prefix = "terraform-provider-"
-    message = <<-EOF
+  repo_prefix = "terraform-provider-"
+  message     = <<-EOF
     This has been released in [version ${var.release_version} of the provider](${var.changelog_link}). Please see the [Terraform documentation on provider versioning](https://www.terraform.io/docs/configuration/providers.html#provider-versions) or reach out if you need any assistance upgrading. As an example:
     ```hcl
     provider "${var.project_name}" {
@@ -12,11 +12,11 @@ queued_behavior "release_commenter" "releases" {
 }
 
 poll "closed_issue_locker" "locker" {
-    schedule = "0 50 14 * * *"
-    closed_for = "720h" # 30 days
-    max_issues = 500
-    sleep_between_issues = "5s"
-    message = <<-EOF
+  schedule = "0 50 14 * * *"
+  closed_for = "720h" # 30 days
+  max_issues = 500
+  sleep_between_issues = "5s"
+  message = <<-EOF
     I'm going to lock this issue because it has been closed for _30 days_ ⏳. This helps our maintainers find and focus on the active issues.
 
     If you feel this issue should be reopened, we encourage creating a new issue linking back to this one for added context. If you feel I made an error 🤖 🙉  , please reach out to my human friends 👉  hashibot-feedback@hashicorp.com. Thanks!

--- a/.hashibot.hcl
+++ b/.hashibot.hcl
@@ -1,0 +1,24 @@
+queued_behavior "release_commenter" "releases" {
+    repo_prefix = "terraform-provider-"
+    message = <<-EOF
+    This has been released in [version ${var.release_version} of the provider](${var.changelog_link}). Please see the [Terraform documentation on provider versioning](https://www.terraform.io/docs/configuration/providers.html#provider-versions) or reach out if you need any assistance upgrading. As an example:
+    ```hcl
+    provider "${var.project_name}" {
+        version = "~> ${var.release_version}"
+    }
+    # ... other configuration ...
+    ```
+    EOF
+}
+
+poll "closed_issue_locker" "locker" {
+    schedule = "0 50 14 * * *"
+    closed_for = "720h" # 30 days
+    max_issues = 500
+    sleep_between_issues = "5s"
+    message = <<-EOF
+    I'm going to lock this issue because it has been closed for _30 days_ ⏳. This helps our maintainers find and focus on the active issues.
+
+    If you feel this issue should be reopened, we encourage creating a new issue linking back to this one for added context. If you feel I made an error 🤖 🙉  , please reach out to my human friends 👉  hashibot-feedback@hashicorp.com. Thanks!
+    EOF
+}

--- a/.hashibot.hcl
+++ b/.hashibot.hcl
@@ -1,6 +1,7 @@
 queued_behavior "release_commenter" "releases" {
   repo_prefix = "terraform-provider-"
-  message     = <<-EOF
+
+  message = <<-EOF
     This has been released in [version ${var.release_version} of the provider](${var.changelog_link}). Please see the [Terraform documentation on provider versioning](https://www.terraform.io/docs/configuration/providers.html#provider-versions) or reach out if you need any assistance upgrading. As an example:
     ```hcl
     provider "${var.project_name}" {
@@ -8,17 +9,18 @@ queued_behavior "release_commenter" "releases" {
     }
     # ... other configuration ...
     ```
-    EOF
+  EOF
 }
 
 poll "closed_issue_locker" "locker" {
-  schedule = "0 50 14 * * *"
-  closed_for = "720h" # 30 days
-  max_issues = 500
+  schedule             = "0 50 16 * * *"
+  closed_for           = "720h" # 30 days
+  max_issues           = 500
   sleep_between_issues = "5s"
+
   message = <<-EOF
     I'm going to lock this issue because it has been closed for _30 days_ ⏳. This helps our maintainers find and focus on the active issues.
 
-    If you feel this issue should be reopened, we encourage creating a new issue linking back to this one for added context. If you feel I made an error 🤖 🙉  , please reach out to my human friends 👉  hashibot-feedback@hashicorp.com. Thanks!
-    EOF
+    If you feel this issue should be reopened, we encourage creating a new issue linking back to this one for added context. If you feel I made an error 🤖 🙉 , please reach out to my human friends 👉  hashibot-feedback@hashicorp.com. Thanks!
+  EOF
 }


### PR DESCRIPTION
This file configures hashibot

Once this PR is merged, as well as the other open PRs to achieve "parity" with what is currently running for the bot in production, I can push the new bot to production. That is to say there is no implication by hitting merge at the moment, but soon this is the place to configure aws provider specific bot behaviors. You can also override/disable some of the global behaviors that are defined here:

https://github.com/terraform-providers/.hashibot/blob/master/.hashibot.hcl

Documentation on this system is in progress.