### PR TITLE
azuread_application: Allow all valid app identifier URI schemes

### DIFF
--- a/azuread/helpers/validate/url.go
+++ b/azuread/helpers/validate/url.go
@@ -16,6 +16,10 @@ func URLIsHTTPOrHTTPS(i interface{}, k string) (_ []string, errors []error) {
 	return URLWithScheme([]string{"http", "https"})(i, k)
 }
 
+func URLIsAppURI(i interface{}, k string) (_ []string, errors []error) {
+	return URLWithScheme([]string{"http", "https", "api", "urn", "ms-appx"})(i, k)
+}
+
 func URLWithScheme(validSchemes []string) schema.SchemaValidateFunc {
 	return func(i interface{}, k string) (_ []string, errors []error) {
 		v, ok := i.(string)

--- a/azuread/helpers/validate/url_test.go
+++ b/azuread/helpers/validate/url_test.go
@@ -87,3 +87,57 @@ func TestURLIsHTTPOrHTTPS(t *testing.T) {
 		})
 	}
 }
+
+func TestURLIsAppURI(t *testing.T) {
+	cases := []struct {
+		Url    string
+		Errors int
+	}{
+		{
+			Url:    "",
+			Errors: 1,
+		},
+		{
+			Url:    "this is not a url",
+			Errors: 1,
+		},
+		{
+			Url:    "www.example.com",
+			Errors: 1,
+		},
+		{
+			Url:    "ftp://www.example.com",
+			Errors: 1,
+		},
+		{
+			Url:    "http://www.example.com",
+			Errors: 0,
+		},
+		{
+			Url:    "https://www.example.com",
+			Errors: 0,
+		},
+		{
+			Url:    "api://www.example.com",
+			Errors: 0,
+		},
+		{
+			Url:    "urn://www.example.com",
+			Errors: 0,
+		},
+		{
+			Url:    "ms-appx://www.example.com",
+			Errors: 0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Url, func(t *testing.T) {
+			_, errors := URLIsAppURI(tc.Url, "test")
+
+			if len(errors) != tc.Errors {
+				t.Fatalf("Expected URLIsAppURI to have %d not %d errors for %q", tc.Errors, len(errors), tc.Url)
+			}
+		})
+	}
+}

--- a/azuread/resource_application.go
+++ b/azuread/resource_application.go
@@ -63,7 +63,7 @@ func resourceApplication() *schema.Resource {
 				Computed: true,
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
-					ValidateFunc: validate.URLIsHTTPOrHTTPS,
+					ValidateFunc: validate.URLIsAppURI,
 				},
 			},
 


### PR DESCRIPTION
As per the Azure Portal, the following schemes are allowed for application ID URIs:

- `https`
- `api`
- `urn`
- `ms-appx`

![Screenshot 2019-07-02 14 08 28](https://user-images.githubusercontent.com/251987/60515456-8f6f9d80-9cd3-11e9-898f-c302af3fdf2b.png)

This change allows these URI schemes to be used, and also retains the already-allowed `http` scheme for compatibility (since that was already allowed, [then disallowed](https://github.com/terraform-providers/terraform-provider-azurerm/pull/1960), [then allowed again](https://github.com/terraform-providers/terraform-provider-azurerm/pull/2320) in the azurerm provider).

![Screenshot 2019-07-02 14 08 54](https://user-images.githubusercontent.com/251987/60515706-20df0f80-9cd4-11e9-9565-29a5f8c38e84.png)

Tests are passing locally for me but I haven't run acceptance tests.