### PR TITLE
Add -All $true to Get-AzureADServicePrincipal

### DIFF
--- a/website/docs/auth/service_principal_configuration.html.markdown
+++ b/website/docs/auth/service_principal_configuration.html.markdown
@@ -66,7 +66,7 @@ if ($role -eq $null) {
 Next we need the Client ID (sometimes referred to as the Application ID) of the Service Principal. We can look this up by it's display name:
 
 ```shell
-$sp = Get-AzureADServicePrincipal | Where-Object {$_.displayName -eq 'Service Principal Name'}
+$sp = Get-AzureADServicePrincipal -All $true | Where-Object {$_.displayName -eq 'Service Principal Name'}
 $sp.ObjectId
 ```
 


### PR DESCRIPTION
To get all the Service Principals from `Get-AzureADServicePrincipal` you need to add the `-All $true` flag.
On a tenant with a lot of service principals you need this flag to retrieve all of them.