### PR TITLE
azuread_user - support for the `usage_location` property

### DIFF
--- a/azuread/data_user.go
+++ b/azuread/data_user.go
@@ -53,6 +53,11 @@ func dataUser() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+
+			"usage_location": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -90,6 +95,7 @@ func dataSourceUserRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("display_name", user.DisplayName)
 	d.Set("mail", user.Mail)
 	d.Set("mail_nickname", user.MailNickname)
+	d.Set("usage_location", user.UsageLocation)
 
 	return nil
 }

--- a/azuread/resource_user.go
+++ b/azuread/resource_user.go
@@ -81,7 +81,7 @@ func resourceUser() *schema.Resource {
 				Computed: true,
 				Description: "A two letter country code (ISO standard 3166). " +
 					"Required for users that will be assigned licenses due to legal requirement to check for availability of services in countries. " +
-					"Examples include: \"NO\", \"JP\", and \"GB\". Not nullable.",
+					"Examples include: `NO`, `P`, and `GB`. Not nullable.",
 			},
 		},
 	}

--- a/azuread/resource_user.go
+++ b/azuread/resource_user.go
@@ -81,7 +81,7 @@ func resourceUser() *schema.Resource {
 				Computed: true,
 				Description: "A two letter country code (ISO standard 3166). " +
 					"Required for users that will be assigned licenses due to legal requirement to check for availability of services in countries. " +
-					"Examples include: `NO`, `P`, and `GB`. Not nullable.",
+					"Examples include: `NO`, `JP`, and `GB`. Not nullable.",
 			},
 		},
 	}

--- a/azuread/resource_user.go
+++ b/azuread/resource_user.go
@@ -74,6 +74,15 @@ func resourceUser() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+
+			"usage_location": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				Description: "A two letter country code (ISO standard 3166). " +
+					"Required for users that will be assigned licenses due to legal requirement to check for availability of services in countries. " +
+					"Examples include: \"NO\", \"JP\", and \"GB\". Not nullable.",
+			},
 		},
 	}
 }
@@ -103,6 +112,10 @@ func resourceUserCreate(d *schema.ResourceData, meta interface{}) error {
 			Password:                     &password,
 		},
 		UserPrincipalName: &upn,
+	}
+
+	if v, ok := d.GetOk("usage_location"); ok {
+		userCreateParameters.UsageLocation = p.String(v.(string))
 	}
 
 	user, err := client.Create(ctx, userCreateParameters)
@@ -146,6 +159,7 @@ func resourceUserRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("mail_nickname", user.MailNickname)
 	d.Set("account_enabled", user.AccountEnabled)
 	d.Set("object_id", user.ObjectID)
+	d.Set("usage_location", user.UsageLocation)
 	return nil
 }
 
@@ -180,6 +194,11 @@ func resourceUserUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		userUpdateParameters.PasswordProfile = passwordProfile
+	}
+
+	if d.HasChange("usage_location") {
+		usageLocation := d.Get("usage_location").(string)
+		userUpdateParameters.UsageLocation = p.String(usageLocation)
 	}
 
 	if _, err := client.Update(ctx, d.Id(), userUpdateParameters); err != nil {

--- a/azuread/resource_user_test.go
+++ b/azuread/resource_user_test.go
@@ -203,6 +203,7 @@ resource "azuread_user" "test" {
   account_enabled       = false
   password              = "%[2]s"
   force_password_change = true
+  usage_location        = "NO"
 }
 `, id, password)
 }

--- a/website/docs/d/user.html.markdown
+++ b/website/docs/d/user.html.markdown
@@ -41,3 +41,4 @@ The following attributes are exported:
 * `display_name` - The Display Name of the Azure AD User.
 * `mail` - The primary email address of the Azure AD User.
 * `mail_nickname` - The email alias of the Azure AD User.
+* `usage_location` - The usage location of the Azure AD User.

--- a/website/docs/r/user.html.markdown
+++ b/website/docs/r/user.html.markdown
@@ -34,7 +34,7 @@ The following arguments are supported:
 * `mail_nickname`- (Optional) The mail alias for the user. Defaults to the user name part of the User Principal Name.
 * `password` - (Required) The password for the User. The password must satisfy minimum requirements as specified by the password policy. The maximum length is 256 characters.
 * `force_password_change` - (Optional) `true` if the User is forced to change the password during the next sign-in. Defaults to `false`.
-* `usage_location` - (Optional) The usage location of the User. Required for users that will be assigned licenses due to legal requirement to check for availability of services in countries. The usage location is a two letter country code (ISO standard 3166). Examples include: "NO", "JP", and "GB". Cannot be reset to null once set. 
+* `usage_location` - (Optional) The usage location of the User. Required for users that will be assigned licenses due to legal requirement to check for availability of services in countries. The usage location is a two letter country code (ISO standard 3166). Examples include: `NO`, `JP`, and `GB`. Cannot be reset to null once set. 
 
 ## Attributes Reference
 

--- a/website/docs/r/user.html.markdown
+++ b/website/docs/r/user.html.markdown
@@ -34,6 +34,7 @@ The following arguments are supported:
 * `mail_nickname`- (Optional) The mail alias for the user. Defaults to the user name part of the User Principal Name.
 * `password` - (Required) The password for the User. The password must satisfy minimum requirements as specified by the password policy. The maximum length is 256 characters.
 * `force_password_change` - (Optional) `true` if the User is forced to change the password during the next sign-in. Defaults to `false`.
+* `usage_location` - (Optional) The usage location of the User. Required for users that will be assigned licenses due to legal requirement to check for availability of services in countries. The usage location is a two letter country code (ISO standard 3166). Examples include: "NO", "JP", and "GB". Cannot be reset to null once set. 
 
 ## Attributes Reference
 


### PR DESCRIPTION
Setting usage location is required for users that will be assigned licenses (e.g. Azure Active Directory Premium P1/2 licenses) due to legal requirement to check for availability of services in countries.