### PR TITLE
Update azuread_group_member import usage snippet

### DIFF
--- a/website/docs/r/group_member.markdown
+++ b/website/docs/r/group_member.markdown
@@ -51,7 +51,7 @@ The following attributes are exported:
 Azure Active Directory Group Members can be imported using the `object id`, e.g.
 
 ```shell
-terraform import azuread_group_member.test 00000000-0000-0000-0000-000000000000/11111111-1111-1111-1111-111111111111
+terraform import azuread_group_member.test 00000000-0000-0000-0000-000000000000/member/UP11111111-1111-1111-1111-111111111111
 ```
 
--> **NOTE:** This ID format is unique to Terraform and is composed of the Azure AD Group Object ID and the target Member Object ID in the format `{GroupObjectID}/{MemberObjectID}`.
+-> **NOTE:** This ID format is unique to Terraform and is composed of the Azure AD Group Object ID and the target Member Object ID in the format `{GroupObjectID}/member/{MemberObjectID}`.


### PR DESCRIPTION

The import usage for the `azuread_group_member` resource doesn't work as documented with error 
``` * import azuread_group_member.xxx result: 000-000-000/111-111-111: azuread_group_member.xxx: Unable to parse ID: Unable to parse Member ID: Object Resource ID should be in the format {objectId}/{keyId} - but got "000-000-000/111-111-111``` but works with `terraform import azuread_group_member.test 00000000-0000-0000-0000-000000000000/member/11111111-1111-1111-1111-111111111111`