### PR TITLE
Update service_principal_password.html.markdown

### DIFF
--- a/website/docs/r/service_principal_password.html.markdown
+++ b/website/docs/r/service_principal_password.html.markdown
@@ -46,7 +46,7 @@ The following arguments are supported:
 
 * `end_date` - (Optional) The End Date which the Password is valid until, formatted as a RFC3339 date string (e.g. `2018-01-01T01:02:03Z`). Changing this field forces a new resource to be created.
 
-* `end_date_relative` - (Optional) A relative duration for which the Password is valid until, for example `240h` (10 days) or `2400h30m`. Changing this field forces a new resource to be created.
+* `end_date_relative` - (Optional) A relative duration for which the Password is valid until, for example `240h` (10 days) or `2400h30m`. Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h". Changing this field forces a new resource to be created. 
 
 -> **NOTE:** One of `end_date` or `end_date_relative` must be set.
 

--- a/website/docs/r/service_principal_password.html.markdown
+++ b/website/docs/r/service_principal_password.html.markdown
@@ -46,7 +46,7 @@ The following arguments are supported:
 
 * `end_date` - (Optional) The End Date which the Password is valid until, formatted as a RFC3339 date string (e.g. `2018-01-01T01:02:03Z`). Changing this field forces a new resource to be created.
 
-* `end_date_relative` - (Optional) A relative duration for which the Password is valid until, for example `240h` (10 days) or `2400h30m`. Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h". Changing this field forces a new resource to be created. 
+* `end_date_relative` - (Optional) A relative duration for which the Password is valid until, for example `240h` (10 days) or `2400h30m`. Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h". Changing this field forces a new resource to be created.
 
 -> **NOTE:** One of `end_date` or `end_date_relative` must be set.
 


### PR DESCRIPTION
Allowed unit for https://www.terraform.io/docs/providers/azuread/r/service_principal_password.html `end_date_relative` was not stated in the documentation.
The implementation commit https://github.com/terraform-providers/terraform-provider-azuread/pull/53/files state that https://golang.org/pkg/time/#ParseDuration is used to parse duration, thus allowing a certain set of units.

This PR add a sentence in the documentation to make that clear.

Added valid duration unit for end_date_relative