### PR TITLE
website: Move auth guides to guides/ folder

### DIFF
--- a/website/azuread.erb
+++ b/website/azuread.erb
@@ -26,22 +26,22 @@
               <a href="#">Authentication</a>
               <ul class="nav nav-visible">
                 <li<%= sidebar_current("docs-azuread-authentication-azure-cli") %>>
-                   <a href="/docs/providers/azuread/auth/azure_cli.html">Authenticating using the Azure CLI</a>
+                   <a href="/docs/providers/azuread/guides/azure_cli.html">Authenticating using the Azure CLI</a>
                 </li>
 
                 <li<%= sidebar_current("docs-azuread-authentication-managed-service-identity") %>>
-                   <a href="/docs/providers/azuread/auth/managed_service_identity.html">Authenticating using Managed Service Identity</a>
+                   <a href="/docs/providers/azuread/guides/managed_service_identity.html">Authenticating using Managed Service Identity</a>
                 </li>
 
                 <li<%= sidebar_current("docs-azuread-authentication-service-principal-client-certificate") %>>
-                   <a href="/docs/providers/azuread/auth/service_principal_client_certificate.html">Authenticating using a Service Principal with a Client Certificate</a>
+                   <a href="/docs/providers/azuread/guides/service_principal_client_certificate.html">Authenticating using a Service Principal with a Client Certificate</a>
                 </li>
 
                 <li<%= sidebar_current("docs-azuread-authentication-service-principal-client-secret") %>>
-                   <a href="/docs/providers/azuread/auth/service_principal_client_secret.html">Authenticating using a Service Principal with a Client Secret</a>
+                   <a href="/docs/providers/azuread/guides/service_principal_client_secret.html">Authenticating using a Service Principal with a Client Secret</a>
                 </li>
                 <li<%= sidebar_current("docs-azuread-configuring-service-principal-client-secret") %>>
-                   <a href="/docs/providers/azuread/auth/service_principal_configuration.html">Configuring a Service Principal</a>
+                   <a href="/docs/providers/azuread/guides/service_principal_configuration.html">Configuring a Service Principal</a>
                 </li>
               </ul>
             </li>

--- a/website/docs/guides/azure_cli.html.markdown
+++ b/website/docs/guides/azure_cli.html.markdown
@@ -1,6 +1,7 @@
 ---
+subcategory: "Authentication"
 layout: "azuread"
-page_title: "Azure Active Directory Provider: Authenticating via the Azure CLI"
+page_title: "Authenticating via the Azure CLI"
 sidebar_current: "docs-azuread-authentication-azure-cli"
 description: |-
   This guide will cover how to use the Azure CLI as authentication for the Azure Active Directory Provider.

--- a/website/docs/guides/managed_service_identity.html.markdown
+++ b/website/docs/guides/managed_service_identity.html.markdown
@@ -1,6 +1,7 @@
 ---
+subcategory: "Authentication"
 layout: "azuread"
-page_title: "Azure Active Directory Provider: Authenticating via Managed Service Identity"
+page_title: "Authenticating via Managed Service Identity"
 sidebar_current: "docs-azuread-authentication-managed-service-identity"
 description: |-
   This guide will cover how to use Managed Service Identity as authentication for the Azure Active Directory Provider.

--- a/website/docs/guides/service_principal_client_certificate.html.markdown
+++ b/website/docs/guides/service_principal_client_certificate.html.markdown
@@ -1,6 +1,7 @@
 ---
+subcategory: "Authentication"
 layout: "azuread"
-page_title: "Azure Active Directory Provider: Authenticating via a Service Principal and a Client Certificate"
+page_title: "Authenticating via a Service Principal and a Client Certificate"
 sidebar_current: "docs-azuread-authentication-service-principal-client-certificate"
 description: |-
   This guide will cover how to use a Service Principal (Shared Account) with a Client Certificate as authentication for the Azure Active Directory Provider.

--- a/website/docs/guides/service_principal_client_secret.html.markdown
+++ b/website/docs/guides/service_principal_client_secret.html.markdown
@@ -1,6 +1,7 @@
 ---
+subcategory: "Authentication"
 layout: "azuread"
-page_title: "Azure Active Directory Provider: Authenticating via a Service Principal and a Client Secret"
+page_title: "Authenticating via a Service Principal and a Client Secret"
 sidebar_current: "docs-azuread-authentication-service-principal-client-secret"
 description: |-
   This guide will cover how to use a Service Principal (Shared Account) with a Client Secret as authentication for the Azure Active Directory Provider.

--- a/website/docs/guides/service_principal_configuration.html.markdown
+++ b/website/docs/guides/service_principal_configuration.html.markdown
@@ -1,6 +1,7 @@
 ---
+subcategory: "Authentication"
 layout: "azuread"
-page_title: "Azure Active Directory Provider: Configuring a Service Principal to manage an Azure Active Directory"
+page_title: "Configuring a Service Principal to manage an Azure Active Directory"
 sidebar_current: "docs-azuread-authentication-configuring-service-principal"
 description: |-
   This guide will cover how to use grant permissions to a Service Principal (Shared Account) to manage objects within an Azure Active Directory .

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -17,10 +17,10 @@ Interested in the provider's latest features, or want to make sure you're up to 
 
 Terraform supports a number of different methods for authenticating to Azure Active Directory:
 
-* [Authenticating to Azure Active Directory using the Azure CLI](auth/azure_cli.html)
-* [Authenticating to Azure Active Directory using Managed Service Identity](auth/managed_service_identity.html)
-* [Authenticating to Azure Active Directory using a Service Principal and a Client Certificate](auth/service_principal_client_certificate.html)
-* [Authenticating to Azure Active Directory using a Service Principal and a Client Secret](auth/service_principal_client_secret.html)
+* [Authenticating to Azure Active Directory using the Azure CLI](guides/azure_cli.html)
+* [Authenticating to Azure Active Directory using Managed Service Identity](guides/managed_service_identity.html)
+* [Authenticating to Azure Active Directory using a Service Principal and a Client Certificate](guides/service_principal_client_certificate.html)
+* [Authenticating to Azure Active Directory using a Service Principal and a Client Secret](guides/service_principal_client_secret.html)
 
 ---
 
@@ -96,7 +96,7 @@ When authenticating as a Service Principal using a Client Certificate, the follo
 
 * `client_certificate_path` - (Optional) The path to the Client Certificate associated with the Service Principal which should be used. This can also be sourced from the `ARM_CLIENT_CERTIFICATE_PATH` Environment Variable.
 
-More information on [how to configure a Service Principal using a Client Certificate can be found in this guide](auth/service_principal_client_certificate.html).
+More information on [how to configure a Service Principal using a Client Certificate can be found in this guide](guides/service_principal_client_certificate.html).
 
 ---
 
@@ -104,7 +104,7 @@ When authenticating as a Service Principal using a Client Secret, the following 
 
 * `client_secret` - (Optional) The Client Secret which should be used. This can also be sourced from the `ARM_CLIENT_SECRET` Environment Variable.
 
-More information on [how to configure a Service Principal using a Client Secret can be found in this guide](auth/service_principal_client_secret.html).
+More information on [how to configure a Service Principal using a Client Secret can be found in this guide](guides/service_principal_client_secret.html).
 
 ---
 
@@ -114,7 +114,7 @@ When authenticating using Managed Service Identity, the following fields can be 
 
 * `use_msi` - (Optional) Should Managed Service Identity be used for Authentication? This can also be sourced from the `ARM_USE_MSI` Environment Variable. Defaults to `false`.
 
-More information on [how to configure a Service Principal using Managed Service Identity can be found in this guide](auth/managed_service_identity.html).
+More information on [how to configure a Service Principal using Managed Service Identity can be found in this guide](guides/managed_service_identity.html).
 
 ---
 

--- a/website/docs/r/service_principal.html.markdown
+++ b/website/docs/r/service_principal.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Manages a Service Principal associated with an Application within Azure Active Directory.
 
--> **NOTE:** If you're authenticating using a Service Principal then it must have permissions to both `Read and write all applications` and `Sign in and read user profile` within the `Windows Azure Active Directory` API. Please see The [Granting a Service Principal permission to manage AAD](../auth/service_principal_configuration.html) for the required steps.
+-> **NOTE:** If you're authenticating using a Service Principal then it must have permissions to both `Read and write all applications` and `Sign in and read user profile` within the `Windows Azure Active Directory` API. Please see The [Granting a Service Principal permission to manage AAD](../guides/service_principal_configuration.html) for the required steps.
 
 ## Example Usage
 


### PR DESCRIPTION
And add subcategories

These changes are required to ensure that docs for this provider display
correctly on registry.terraform.io.

For more information about how documentation is rendered on the Terraform Registry, please see this reference: [Terraform Registry - Provider Documentation](https://www.terraform.io/docs/registry/providers/docs.html).

**This should not be merged until a future PR on hashicorp/terraform-website is ready to merge with redirects for these moved files.**