### PR TITLE
azuread_groups - sidebar and doc fix

### DIFF
--- a/website/azuread.erb
+++ b/website/azuread.erb
@@ -61,7 +61,9 @@
                 <li<%= sidebar_current("docs-azuread-datasource-azuread-group") %>>
                   <a href="/docs/providers/azuread/d/group.html">azuread_group</a>
                 </li>
-
+                <li<%= sidebar_current("docs-azuread-datasource-azuread-groups") %>>
+                  <a href="/docs/providers/azuread/d/groups.html">azuread_groups</a>
+                </li>
                 <li<%= sidebar_current("docs-azuread-datasource-azuread-application") %>>
                   <a href="/docs/providers/azuread/d/service_principal.html">azuread_service_principal</a>
                 </li>

--- a/website/docs/d/groups.html.markdown
+++ b/website/docs/d/groups.html.markdown
@@ -7,7 +7,7 @@ description: |-
 
 ---
 
-# Data Source: azuread_user
+# Data Source: azuread_groups
 
 Gets Object IDs or Display Names for multiple Azure Active Directory groups.
 


### PR DESCRIPTION
- looks like website sidebar documentation link missed in https://github.com/terraform-providers/terraform-provider-azuread/pull/120, 