### PR TITLE
Update go version in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ General Requirements
 ------------
 
 -	[Terraform](https://www.terraform.io/downloads.html) 0.10.x
--	[Go](https://golang.org/doc/install) 1.11.x (to build the provider plugin)
+-	[Go](https://golang.org/doc/install) 1.13.x (to build the provider plugin)
 
 Windows Specific Requirements
 -----------------------------
@@ -69,7 +69,7 @@ Further [usage documentation is available on the Terraform website](https://www.
 Developing the Provider
 ---------------------------
 
-If you wish to work on the provider, you'll first need [Go](http://www.golang.org) installed on your machine (version 1.9+ is *required*). You'll also need to correctly setup a [GOPATH](http://golang.org/doc/code.html#GOPATH), as well as adding `$GOPATH/bin` to your `$PATH`.
+If you wish to work on the provider, you'll first need [Go](http://www.golang.org) installed on your machine (version 1.13+ is *required*). You'll also need to correctly setup a [GOPATH](http://golang.org/doc/code.html#GOPATH), as well as adding `$GOPATH/bin` to your `$PATH`.
 
 To compile the provider, run `make build`. This will build the provider and put the provider binary in the `$GOPATH/bin` directory.
 


### PR DESCRIPTION
Based on the version of go in [go.mod](https://github.com/brunhil/terraform-provider-azuread/blob/update-readme-goversion/go.mod), we should be stating we require version 1.13.