### PR TITLE
Fixes #201. Changed date to 2099 to prevent issue.

### DIFF
--- a/azuread/resource_application_password_test.go
+++ b/azuread/resource_application_password_test.go
@@ -94,7 +94,7 @@ func TestAccAzureADApplicationPassword_basic(t *testing.T) {
 					testCheckADApplicationPasswordExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "start_date"),
 					resource.TestCheckResourceAttrSet(resourceName, "key_id"),
-					resource.TestCheckResourceAttr(resourceName, "end_date", "2020-01-01T01:02:03Z"),
+					resource.TestCheckResourceAttr(resourceName, "end_date", "2099-01-01T01:02:03Z"),
 				),
 			},
 		},
@@ -118,7 +118,7 @@ func TestAccAzureADApplicationPassword_basicOld(t *testing.T) {
 					testCheckADApplicationPasswordExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "start_date"),
 					resource.TestCheckResourceAttrSet(resourceName, "key_id"),
-					resource.TestCheckResourceAttr(resourceName, "end_date", "2020-01-01T01:02:03Z"),
+					resource.TestCheckResourceAttr(resourceName, "end_date", "2099-01-01T01:02:03Z"),
 				),
 			},
 		},
@@ -171,7 +171,7 @@ func TestAccAzureADApplicationPassword_customKeyId(t *testing.T) {
 					testCheckADApplicationPasswordExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "start_date"),
 					resource.TestCheckResourceAttr(resourceName, "key_id", keyId),
-					resource.TestCheckResourceAttr(resourceName, "end_date", "2020-01-01T01:02:03Z"),
+					resource.TestCheckResourceAttr(resourceName, "end_date", "2099-01-01T01:02:03Z"),
 				),
 			},
 		},
@@ -217,7 +217,7 @@ func testAccADObjectPasswordApplication_basic(applicationId, value string) strin
 resource "azuread_application_password" "test" {
   application_object_id = "${azuread_application.test.id}"
   value                 = "%s"
-  end_date              = "2020-01-01T01:02:03Z"
+  end_date              = "2099-01-01T01:02:03Z"
 }
 `, testAccADApplicationPassword_template(applicationId), value)
 }
@@ -229,7 +229,7 @@ func testAccADObjectPasswordApplication_basicOld(applicationId, value string) st
 resource "azuread_application_password" "test" {
   application_id = "${azuread_application.test.id}"
   value          = "%s"
-  end_date       = "2020-01-01T01:02:03Z"
+  end_date       = "2099-01-01T01:02:03Z"
 }
 `, testAccADApplicationPassword_template(applicationId), value)
 }
@@ -256,7 +256,7 @@ resource "azuread_application_password" "test" {
   application_object_id = "${azuread_application.test.id}"
   key_id                = "%s"
   value                 = "%s"
-  end_date              = "2020-01-01T01:02:03Z"
+  end_date              = "2099-01-01T01:02:03Z"
 }
 `, testAccADApplicationPassword_template(applicationId), keyId, value)
 }

--- a/azuread/resource_service_principal_password_test.go
+++ b/azuread/resource_service_principal_password_test.go
@@ -95,7 +95,7 @@ func TestAccAzureADServicePrincipalPassword_basic(t *testing.T) {
 					testCheckADServicePrincipalPasswordExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "start_date"),
 					resource.TestCheckResourceAttrSet(resourceName, "key_id"),
-					resource.TestCheckResourceAttr(resourceName, "end_date", "2020-01-01T01:02:03Z"),
+					resource.TestCheckResourceAttr(resourceName, "end_date", "2099-01-01T01:02:03Z"),
 				),
 			},
 		},
@@ -149,7 +149,7 @@ func TestAccAzureADServicePrincipalPassword_customKeyId(t *testing.T) {
 					testCheckADServicePrincipalPasswordExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "start_date"),
 					resource.TestCheckResourceAttr(resourceName, "key_id", keyId),
-					resource.TestCheckResourceAttr(resourceName, "end_date", "2020-01-01T01:02:03Z"),
+					resource.TestCheckResourceAttr(resourceName, "end_date", "2099-01-01T01:02:03Z"),
 				),
 			},
 		},
@@ -199,7 +199,7 @@ func testAccADServicePrincipalPassword_basic(applicationId, value string) string
 resource "azuread_service_principal_password" "test" {
   service_principal_id = "${azuread_service_principal.test.id}"
   value                = "%s"
-  end_date             = "2020-01-01T01:02:03Z"
+  end_date             = "2099-01-01T01:02:03Z"
 }
 `, testAccADServicePrincipalPassword_template(applicationId), value)
 }
@@ -226,7 +226,7 @@ resource "azuread_service_principal_password" "test" {
   service_principal_id = "${azuread_service_principal.test.id}"
   key_id               = "%s"
   value                = "%s"
-  end_date             = "2020-01-01T01:02:03Z"
+  end_date             = "2099-01-01T01:02:03Z"
 }
 `, testAccADServicePrincipalPassword_template(applicationId), keyId, value)
 }

--- a/website/docs/r/application_password.html.markdown
+++ b/website/docs/r/application_password.html.markdown
@@ -28,7 +28,7 @@ resource "azuread_application" "example" {
 resource "azuread_application_password" "example" {
   application_id = "${azuread_application.example.id}"
   value          = "VT=uSgbTanZhyz@%nL9Hpd+Tfay_MRV#"
-  end_date       = "2020-01-01T01:02:03Z"
+  end_date       = "2099-01-01T01:02:03Z"
 }
 ```
 

--- a/website/docs/r/service_principal_password.html.markdown
+++ b/website/docs/r/service_principal_password.html.markdown
@@ -32,7 +32,7 @@ resource "azuread_service_principal" "example" {
 resource "azuread_service_principal_password" "example" {
   service_principal_id = "${azuread_service_principal.test.id}"
   value                = "VT=uSgbTanZhyz@%nL9Hpd+Tfay_MRV#"
-  end_date             = "2020-01-01T01:02:03Z"
+  end_date             = "2099-01-01T01:02:03Z"
 }
 ```
 


### PR DESCRIPTION
Fixes issue in tests and documentation where the tests uses 2020-01-01 as a date meant to be in the future. Have changed this to 2099 to prevent this issue from happening again.