### PR TITLE
azuread_group - owners is now additive on creation allowing existing owner to be in owners list

### DIFF
--- a/azuread/resource_group.go
+++ b/azuread/resource_group.go
@@ -101,8 +101,14 @@ func resourceGroupCreate(d *schema.ResourceData, meta interface{}) error {
 
 	// Add owners if specified
 	if v, ok := d.GetOk("owners"); ok {
-		members := tf.ExpandStringSlicePtr(v.(*schema.Set).List())
-		if err := graph.GroupAddOwners(client, ctx, *group.ObjectID, *members); err != nil {
+		existingOwners, err := graph.GroupAllOwners(client, ctx, *group.ObjectID)
+		if err != nil {
+			return err
+		}
+		members := *tf.ExpandStringSlicePtr(v.(*schema.Set).List())
+		ownersToAdd := slices.Difference(members, existingOwners)
+
+		if err := graph.GroupAddOwners(client, ctx, *group.ObjectID, ownersToAdd); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Fixed func resourceGroupCreate. From now you can pass your object_id to the owner list

(fixes #212)