### PR TITLE
Update data_group outputs in docs (#196)

### DIFF
--- a/website/docs/d/group.html.markdown
+++ b/website/docs/d/group.html.markdown
@@ -36,4 +36,7 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - The Object ID of the Azure AD Group.
+* `name` - The name of the Azure AD Group.
+* `owners` - The Object IDs of the Azure AD Group owners.
+* `members` - The Object IDs of the Azure AD Group members.
 


### PR DESCRIPTION
I saw that exporting group owners is implemented, but documentation is not synched with implementation.

fixes #196