### PR TITLE
azuread_application - Removed unrequired validation

### DIFF
--- a/azuread/resource_application.go
+++ b/azuread/resource_application.go
@@ -64,7 +64,6 @@ func resourceApplication() *schema.Resource {
 				Computed: true,
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
-					ValidateFunc: validate.URLIsAppURI,
 				},
 			},
 

--- a/azuread/resource_application.go
+++ b/azuread/resource_application.go
@@ -63,7 +63,7 @@ func resourceApplication() *schema.Resource {
 				Optional: true,
 				Computed: true,
 				Elem: &schema.Schema{
-					Type:         schema.TypeString,
+					Type: schema.TypeString,
 				},
 			},
 


### PR DESCRIPTION
The Azure Portal does not enforce the `identifier_uris` / `entity id` to be in a valid URL format. 

There is also a 3rd party gallery app called box which required this to be `box.net` which fails under the current func `validate.URLIsAppURI `

Documentation around said 3rd party app which requires a non url based value can be found [here](https://community.box.com/t5/How-to-Guides-for-Admins/Setting-Up-Single-Sign-On-SSO-for-your-Enterprise/ta-p/1263)

You can also this see this is true and valid via official Microsoft Docs [here](https://docs.microsoft.com/en-us/azure/active-directory/saas-apps/box-tutorial#configure-azure-ad-sso)
