### PR TITLE
azuread_user - add `onpremises_sam_account_name` and `onpremises_user_principal_name`

### DIFF
--- a/azuread/data_user.go
+++ b/azuread/data_user.go
@@ -57,6 +57,16 @@ func dataUser() *schema.Resource {
 				Computed: true,
 			},
 
+			"on_premises_sam_account_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"on_premises_user_principal_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"usage_location": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -104,6 +114,8 @@ func dataSourceUserRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("display_name", user.DisplayName)
 	d.Set("mail", user.Mail)
 	d.Set("mail_nickname", user.MailNickname)
+	d.Set("on_premises_sam_account_name", user.AdditionalProperties["onPremisesSamAccountName"])
+	d.Set("on_premises_user_principal_name", user.AdditionalProperties["onPremisesUserPrincipalName"])
 	d.Set("usage_location", user.UsageLocation)
 
 	return nil

--- a/azuread/data_user.go
+++ b/azuread/data_user.go
@@ -57,12 +57,12 @@ func dataUser() *schema.Resource {
 				Computed: true,
 			},
 
-			"on_premises_sam_account_name": {
+			"onpremises_sam_account_name": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
 
-			"on_premises_user_principal_name": {
+			"onpremises_user_principal_name": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -114,9 +114,10 @@ func dataSourceUserRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("display_name", user.DisplayName)
 	d.Set("mail", user.Mail)
 	d.Set("mail_nickname", user.MailNickname)
-	d.Set("on_premises_sam_account_name", user.AdditionalProperties["onPremisesSamAccountName"])
-	d.Set("on_premises_user_principal_name", user.AdditionalProperties["onPremisesUserPrincipalName"])
 	d.Set("usage_location", user.UsageLocation)
+
+	d.Set("onpremises_sam_account_name", user.AdditionalProperties["onPremisesSamAccountName"])
+	d.Set("onpremises_user_principal_name", user.AdditionalProperties["onPremisesUserPrincipalName"])
 
 	return nil
 }

--- a/azuread/resource_user.go
+++ b/azuread/resource_user.go
@@ -70,6 +70,16 @@ func resourceUser() *schema.Resource {
 				Computed: true,
 			},
 
+			"onpremises_sam_account_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"onpremises_user_principal_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"object_id": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -160,6 +170,10 @@ func resourceUserRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("account_enabled", user.AccountEnabled)
 	d.Set("object_id", user.ObjectID)
 	d.Set("usage_location", user.UsageLocation)
+
+	d.Set("onpremises_sam_account_name", user.AdditionalProperties["onPremisesSamAccountName"])
+	d.Set("onpremises_user_principal_name", user.AdditionalProperties["onPremisesUserPrincipalName"])
+
 	return nil
 }
 

--- a/website/docs/d/user.html.markdown
+++ b/website/docs/d/user.html.markdown
@@ -43,4 +43,7 @@ The following attributes are exported:
 * `display_name` - The Display Name of the Azure AD User.
 * `mail` - The primary email address of the Azure AD User.
 * `mail_nickname` - The email alias of the Azure AD User.
+* `mail_nickname` - The email alias of the Azure AD User.
+* `onpremises_sam_account_name` - The on premise sam account name of the Azure AD User.
+* `onpremises_user_principal_name` - The on premise user principal name of the Azure AD User.
 * `usage_location` - The usage location of the Azure AD User.

--- a/website/docs/r/user.html.markdown
+++ b/website/docs/r/user.html.markdown
@@ -40,9 +40,11 @@ The following arguments are supported:
 
 The following attributes are exported:
 
-* `object_id` - The Object ID of the Azure AD User.
 * `id` - The Object ID of the Azure AD User.
 * `mail` - The primary email address of the Azure AD User.
+* `onpremises_sam_account_name` - The on premise sam account name of the Azure AD User.
+* `onpremises_user_principal_name` - The on premise user principal name of the Azure AD User.
+* `object_id` - The Object ID of the Azure AD User.
 
 ## Import
 


### PR DESCRIPTION
Adds a couple on premises values required for our use:
- on_premises_sam_account_name
- on_premises_user_principal_name

Documented here: https://docs.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-1.0

Should exist within Azure SDK: https://github.com/Azure/azure-sdk-for-go/blob/master/services/graphrbac/1.6/graphrbac/models.go#L3756