### PR TITLE
Remove MinItems from data groups

### DIFF
--- a/azuread/data_groups.go
+++ b/azuread/data_groups.go
@@ -26,7 +26,6 @@ func dataGroups() *schema.Resource {
 				Type:          schema.TypeList,
 				Optional:      true,
 				Computed:      true,
-				MinItems:      1,
 				ConflictsWith: []string{"names"},
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
@@ -38,7 +37,6 @@ func dataGroups() *schema.Resource {
 				Type:          schema.TypeList,
 				Optional:      true,
 				Computed:      true,
-				MinItems:      1,
 				ConflictsWith: []string{"object_ids"},
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
@@ -75,8 +73,6 @@ func dataSourceGroupsRead(d *schema.ResourceData, meta interface{}) error {
 
 			groups = append(groups, resp)
 		}
-	} else {
-		return fmt.Errorf("one of `object_ids` or `names` must be supplied")
 	}
 
 	if len(groups) != expectedCount {

--- a/website/docs/d/groups.html.markdown
+++ b/website/docs/d/groups.html.markdown
@@ -25,11 +25,9 @@ data "azuread_groups" "groups" {
 
 The following arguments are supported:
 
-* `names` - (optional) The Display Names of the Azure AD Groups.
+* `names` - (Optional) The Display Names of the Azure AD Groups.
 
 * `object_ids` - (Optional) The Object IDs of the Azure AD Groups.
-
--> **NOTE:** Either `names` or `object_ids` must be specified.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Was trying to use the `azuread_groups` with the optional `names` parameter, but was getting an error about a value must be returned as they are both set to 1 and return an error.

Looks like a similar issue to: https://github.com/terraform-providers/terraform-provider-azuread/pull/227