### PR TITLE
Added support for ApplicationGroup

### DIFF
--- a/azuread/data_application_test.go
+++ b/azuread/data_application_test.go
@@ -67,7 +67,6 @@ func TestAccAzureADApplicationDataSource_byObjectIdComplete(t *testing.T) {
 					resource.TestCheckResourceAttr(dataSourceName, "oauth2_allow_implicit_flow", "true"),
 					resource.TestCheckResourceAttr(dataSourceName, "required_resource_access.#", "2"),
 					resource.TestCheckResourceAttr(dataSourceName, "group_membership_claims", "All"),
-					resource.TestCheckResourceAttr(dataSourceName, "group_membership_claims", "ApplicationGroup"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "application_id"),
 				),
 			},

--- a/azuread/data_application_test.go
+++ b/azuread/data_application_test.go
@@ -67,6 +67,7 @@ func TestAccAzureADApplicationDataSource_byObjectIdComplete(t *testing.T) {
 					resource.TestCheckResourceAttr(dataSourceName, "oauth2_allow_implicit_flow", "true"),
 					resource.TestCheckResourceAttr(dataSourceName, "required_resource_access.#", "2"),
 					resource.TestCheckResourceAttr(dataSourceName, "group_membership_claims", "All"),
+					resource.TestCheckResourceAttr(dataSourceName, "group_membership_claims", "ApplicationGroup"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "application_id"),
 				),
 			},

--- a/azuread/resource_application.go
+++ b/azuread/resource_application.go
@@ -50,7 +50,7 @@ func resourceApplication() *schema.Resource {
 					string(graphrbac.All),
 					string(graphrbac.None),
 					string(graphrbac.SecurityGroup),
-					"DirectoryRole", // missing from sdk: https://github.com/Azure/azure-sdk-for-go/issues/7857
+					"DirectoryRole",    // missing from sdk: https://github.com/Azure/azure-sdk-for-go/issues/7857
 					"ApplicationGroup", //missing from sdk:https://github.com/Azure/azure-sdk-for-go/issues/8244
 				}, false),
 			},

--- a/azuread/resource_application.go
+++ b/azuread/resource_application.go
@@ -51,6 +51,7 @@ func resourceApplication() *schema.Resource {
 					string(graphrbac.None),
 					string(graphrbac.SecurityGroup),
 					"DirectoryRole", // missing from sdk: https://github.com/Azure/azure-sdk-for-go/issues/7857
+					"ApplicationGroup", //missing from sdk:https://github.com/Azure/azure-sdk-for-go/issues/8244
 				}, false),
 			},
 

--- a/azuread/resource_application_test.go
+++ b/azuread/resource_application_test.go
@@ -66,6 +66,7 @@ func TestAccAzureADApplication_complete(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "identifier_uris.0", fmt.Sprintf("http://%d.hashicorptest.com/00000000-0000-0000-0000-00000000", ri)),
 					resource.TestCheckResourceAttr(resourceName, "reply_urls.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "group_membership_claims", "All"),
+					resource.TestCheckResourceAttr(resourceName, "group_membership_claims", "ApplicationGroup"),
 					resource.TestCheckResourceAttr(resourceName, "required_resource_access.#", "2"),
 					resource.TestCheckResourceAttrSet(resourceName, "application_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "object_id"),

--- a/azuread/resource_application_test.go
+++ b/azuread/resource_application_test.go
@@ -66,7 +66,6 @@ func TestAccAzureADApplication_complete(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "identifier_uris.0", fmt.Sprintf("http://%d.hashicorptest.com/00000000-0000-0000-0000-00000000", ri)),
 					resource.TestCheckResourceAttr(resourceName, "reply_urls.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "group_membership_claims", "All"),
-					resource.TestCheckResourceAttr(resourceName, "group_membership_claims", "ApplicationGroup"),
 					resource.TestCheckResourceAttr(resourceName, "required_resource_access.#", "2"),
 					resource.TestCheckResourceAttrSet(resourceName, "application_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "object_id"),
@@ -376,6 +375,13 @@ func TestAccAzureADApplication_groupMembershipClaimsUpdate(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccADApplication_withGroupMembershipClaimsApplicationGroup(ri),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckADApplicationExists(rn),
+					resource.TestCheckResourceAttr(rn, "group_membership_claims", "ApplicationGroup"),
+				),
+			},
+			{
 				ResourceName:      rn,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -629,6 +635,15 @@ func testAccADApplication_withGroupMembershipClaimsSecurityGroup(ri int) string 
 resource "azuread_application" "test" {
   name                    = "acctest-APP-%[1]d"
   group_membership_claims = "SecurityGroup"
+}
+`, ri)
+}
+
+func testAccADApplication_withGroupMembershipClaimsApplicationGroup(ri int) string {
+	return fmt.Sprintf(`
+resource "azuread_application" "test" {
+  name                    = "acctest-APP-%[1]d"
+  group_membership_claims = "ApplicationGroup"
 }
 `, ri)
 }

--- a/website/docs/r/application.html.markdown
+++ b/website/docs/r/application.html.markdown
@@ -88,7 +88,7 @@ The following arguments are supported:
 
 * `oauth2_allow_implicit_flow` - (Optional) Does this Azure AD Application allow OAuth2.0 implicit flow tokens? Defaults to `false`.
 
-* `group_membership_claims` - (Optional) Configures the `groups` claim issued in a user or OAuth 2.0 access token that the app expects. Defaults to `SecurityGroup`. Possible values are `None`, `SecurityGroup` or `All`.
+* `group_membership_claims` - (Optional) Configures the `groups` claim issued in a user or OAuth 2.0 access token that the app expects. Defaults to `SecurityGroup`. Possible values are `None`, `SecurityGroup`, `DirectoryRole`, `ApplicationGroup` or `All`.
 
 * `owners` - (Optional) A list of Azure AD Object IDs that will be granted ownership of the application. Defaults to the Object ID of the caller creating the application. If a list is specified the caller Object ID will no longer be included unless explicitly added to the list. 
 


### PR DESCRIPTION
Added support to use ApplicationGroup as a valid group_membership_claims option. 

Updated docs to include this also 

Issue detailing this change can be found here https://github.com/terraform-providers/terraform-provider-azuread/issues/239