### PR TITLE
Removed forceNew flag from resource_service_principal tags

### DIFF
--- a/azuread/resource_service_principal.go
+++ b/azuread/resource_service_principal.go
@@ -114,6 +114,15 @@ func resourceServicePrincipalUpdate(d *schema.ResourceData, meta interface{}) er
 		properties.AppRoleAssignmentRequired = p.Bool(d.Get("app_role_assignment_required").(bool))
 	}
 
+	if d.HasChange("tags") {
+		if v, ok := d.GetOk("tags"); ok {
+			properties.Tags = tf.ExpandStringSlicePtr(v.(*schema.Set).List())
+		} else {
+			empty := []string{} // clear tags with empty array
+			properties.Tags = &empty
+		}
+	}
+
 	if _, err := client.Update(ctx, d.Id(), properties); err != nil {
 		return fmt.Errorf("Error patching Azure AD Service Principal with ID %q: %+v", d.Id(), err)
 	}

--- a/azuread/resource_service_principal.go
+++ b/azuread/resource_service_principal.go
@@ -55,7 +55,6 @@ func resourceServicePrincipal() *schema.Resource {
 			"tags": {
 				Type:     schema.TypeSet,
 				Optional: true,
-				ForceNew: true,
 				Set:      schema.HashString,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,

--- a/azuread/resource_service_principal.go
+++ b/azuread/resource_service_principal.go
@@ -64,6 +64,7 @@ func resourceServicePrincipal() *schema.Resource {
 	}
 }
 
+
 func resourceServicePrincipalCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ArmClient).servicePrincipalsClient
 	ctx := meta.(*ArmClient).StopContext

--- a/azuread/resource_service_principal.go
+++ b/azuread/resource_service_principal.go
@@ -16,6 +16,7 @@ import (
 )
 
 const servicePrincipalResourceName = "azuread_service_principal"
+
 func resourceServicePrincipal() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceServicePrincipalCreate,
@@ -62,7 +63,6 @@ func resourceServicePrincipal() *schema.Resource {
 		},
 	}
 }
-
 
 func resourceServicePrincipalCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ArmClient).servicePrincipalsClient

--- a/azuread/resource_service_principal.go
+++ b/azuread/resource_service_principal.go
@@ -16,7 +16,6 @@ import (
 )
 
 const servicePrincipalResourceName = "azuread_service_principal"
-
 func resourceServicePrincipal() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceServicePrincipalCreate,


### PR DESCRIPTION
You can update a service principal's tags without destroy it using the graph API or powershell, so there is no reason why this provider should force a new Service Principal 