### PR TITLE
Update Azure Go SDK version to v42.1.0

### DIFF
--- a/azuread/helpers/graph/user.go
+++ b/azuread/helpers/graph/user.go
@@ -9,7 +9,7 @@ import (
 
 func UserGetByObjectId(client *graphrbac.UsersClient, ctx context.Context, objectId string) (*graphrbac.User, error) {
 	filter := fmt.Sprintf("objectId eq '%s'", objectId)
-	resp, err := client.ListComplete(ctx, filter)
+	resp, err := client.ListComplete(ctx, filter, "")
 	if err != nil {
 		return nil, fmt.Errorf("Error listing Azure AD Users for filter %q: %+v", filter, err)
 	}
@@ -38,7 +38,7 @@ func UserGetByObjectId(client *graphrbac.UsersClient, ctx context.Context, objec
 
 func UserGetByMailNickname(client *graphrbac.UsersClient, ctx context.Context, mailNickname string) (*graphrbac.User, error) {
 	filter := fmt.Sprintf("startswith(mailNickname,'%s')", mailNickname)
-	resp, err := client.ListComplete(ctx, filter)
+	resp, err := client.ListComplete(ctx, filter, "")
 	if err != nil {
 		return nil, fmt.Errorf("Error listing Azure AD Users for filter %q: %+v", filter, err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/terraform-providers/terraform-provider-azuread
 
 require (
-	github.com/Azure/azure-sdk-for-go v40.3.0+incompatible
+	github.com/Azure/azure-sdk-for-go v42.1.0+incompatible
 	github.com/Azure/go-autorest/autorest v0.10.0
 	github.com/Azure/go-autorest/autorest/date v0.2.0
 	github.com/google/uuid v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ cloud.google.com/go/bigquery v1.0.1/go.mod h1:i/xbL2UlR5RvWAURpBYZTtm/cXjCha9lbf
 cloud.google.com/go/datastore v1.0.0/go.mod h1:LXYbyblFSglQ5pkeyhO+Qmw7ukd3C+pD7TKLgZqpHYE=
 github.com/Azure/azure-sdk-for-go v35.0.0+incompatible h1:PkmdmQUmeSdQQ5258f4SyCf2Zcz0w67qztEg37cOR7U=
 github.com/Azure/azure-sdk-for-go v35.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
-github.com/Azure/azure-sdk-for-go v40.3.0+incompatible h1:NthZg3psrLxvQLN6rVm07pZ9mv2wvGNaBNGQ3fnPvLE=
-github.com/Azure/azure-sdk-for-go v40.3.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
+github.com/Azure/azure-sdk-for-go v42.1.0+incompatible h1:ZNliGuvGKIHedRdz8W9BTMSrxBv9Nzz5BjeobotQTAI=
+github.com/Azure/azure-sdk-for-go v42.1.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/go-autorest/autorest v0.9.0 h1:MRvx8gncNaXJqOoLmhNjUAKh33JJF8LyxPhomEtOsjs=
 github.com/Azure/go-autorest/autorest v0.9.0/go.mod h1:xyHB1BMZT0cuDHU7I0+g046+BFDTQ8rEZB0s4Yfa6bI=
 github.com/Azure/go-autorest/autorest v0.9.2 h1:6AWuh3uWrsZJcNoCHrCF/+g4aKPCU39kaMO6/qrnK/4=

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/graphrbac/1.6/graphrbac/users.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/graphrbac/1.6/graphrbac/users.go
@@ -362,7 +362,8 @@ func (client UsersClient) GetMemberGroupsResponder(resp *http.Response) (result 
 // List gets list of users for the current tenant.
 // Parameters:
 // filter - the filter to apply to the operation.
-func (client UsersClient) List(ctx context.Context, filter string) (result UserListResultPage, err error) {
+// expand - the expand value for the operation result.
+func (client UsersClient) List(ctx context.Context, filter string, expand string) (result UserListResultPage, err error) {
 	if tracing.IsEnabled() {
 		ctx = tracing.StartSpan(ctx, fqdn+"/UsersClient.List")
 		defer func() {
@@ -379,7 +380,7 @@ func (client UsersClient) List(ctx context.Context, filter string) (result UserL
 		}
 		return client.ListNext(ctx, *lastResult.OdataNextLink)
 	}
-	req, err := client.ListPreparer(ctx, filter)
+	req, err := client.ListPreparer(ctx, filter, expand)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "graphrbac.UsersClient", "List", nil, "Failure preparing request")
 		return
@@ -401,7 +402,7 @@ func (client UsersClient) List(ctx context.Context, filter string) (result UserL
 }
 
 // ListPreparer prepares the List request.
-func (client UsersClient) ListPreparer(ctx context.Context, filter string) (*http.Request, error) {
+func (client UsersClient) ListPreparer(ctx context.Context, filter string, expand string) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"tenantID": autorest.Encode("path", client.TenantID),
 	}
@@ -412,6 +413,9 @@ func (client UsersClient) ListPreparer(ctx context.Context, filter string) (*htt
 	}
 	if len(filter) > 0 {
 		queryParameters["$filter"] = autorest.Encode("query", filter)
+	}
+	if len(expand) > 0 {
+		queryParameters["$expand"] = autorest.Encode("query", expand)
 	}
 
 	preparer := autorest.CreatePreparer(
@@ -442,7 +446,7 @@ func (client UsersClient) ListResponder(resp *http.Response) (result UserListRes
 }
 
 // ListComplete enumerates all values, automatically crossing page boundaries as required.
-func (client UsersClient) ListComplete(ctx context.Context, filter string) (result UserListResultIterator, err error) {
+func (client UsersClient) ListComplete(ctx context.Context, filter string, expand string) (result UserListResultIterator, err error) {
 	if tracing.IsEnabled() {
 		ctx = tracing.StartSpan(ctx, fqdn+"/UsersClient.List")
 		defer func() {
@@ -453,7 +457,7 @@ func (client UsersClient) ListComplete(ctx context.Context, filter string) (resu
 			tracing.EndSpan(ctx, sc, err)
 		}()
 	}
-	result.page, err = client.List(ctx, filter)
+	result.page, err = client.List(ctx, filter, expand)
 	return
 }
 

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/graphrbac/1.6/graphrbac/version.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/graphrbac/1.6/graphrbac/version.go
@@ -21,7 +21,7 @@ import "github.com/Azure/azure-sdk-for-go/version"
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/" + version.Number + " graphrbac/1.6"
+	return "Azure-SDK-For-Go/" + Version() + " graphrbac/1.6"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.

--- a/vendor/github.com/Azure/azure-sdk-for-go/version/version.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/version/version.go
@@ -18,4 +18,4 @@ package version
 // Changes may cause incorrect behavior and will be lost if the code is regenerated.
 
 // Number contains the semantic version of this SDK.
-const Number = "v40.3.0"
+const Number = "v42.1.0"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -6,7 +6,7 @@ cloud.google.com/go/internal/optional
 cloud.google.com/go/internal/trace
 cloud.google.com/go/internal/version
 cloud.google.com/go/storage
-# github.com/Azure/azure-sdk-for-go v40.3.0+incompatible
+# github.com/Azure/azure-sdk-for-go v42.1.0+incompatible
 github.com/Azure/azure-sdk-for-go/services/graphrbac/1.6/graphrbac
 github.com/Azure/azure-sdk-for-go/version
 # github.com/Azure/go-autorest/autorest v0.10.0


### PR DESCRIPTION
There is a breaking change on `UserClient.List()` function in package **graphrbac**. This blocks terraform-provider-azurerm from updating the Azure Go SDK to v42.1.0.