### PR TITLE
Support descriptions for azuread_application_password / azuread_service_principal_password

### DIFF
--- a/azuread/helpers/graph/credentials.go
+++ b/azuread/helpers/graph/credentials.go
@@ -35,6 +35,13 @@ func PasswordResourceSchema(object_type string) map[string]*schema.Schema {
 			ValidateFunc: validate.UUID,
 		},
 
+		"description": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+			ForceNew: true,
+		},
+
 		"value": {
 			Type:         schema.TypeString,
 			Required:     true,
@@ -139,6 +146,11 @@ func PasswordCredentialForResource(d *schema.ResourceData) (*graphrbac.PasswordC
 		KeyID:   p.String(keyId),
 		Value:   p.String(value),
 		EndDate: &date.Time{Time: endDate},
+	}
+
+	if v, ok := d.GetOk("description"); ok {
+		customIdentifier := []byte(v.(string))
+		credential.CustomKeyIdentifier = &customIdentifier
 	}
 
 	if v, ok := d.GetOk("start_date"); ok {

--- a/azuread/resource_application_password.go
+++ b/azuread/resource_application_password.go
@@ -180,7 +180,7 @@ func resourceApplicationPasswordRead(d *schema.ResourceData, meta interface{}) e
 	d.Set("application_object_id", id.ObjectId)
 	d.Set("application_id", id.ObjectId) //todo remove in 2.0
 	d.Set("key_id", id.KeyId)
-	d.Set("description", credential.CustomKeyIdentifier)
+	d.Set("description", string(*credential.CustomKeyIdentifier))
 
 	if endDate := credential.EndDate; endDate != nil {
 		d.Set("end_date", endDate.Format(time.RFC3339))

--- a/azuread/resource_application_password.go
+++ b/azuread/resource_application_password.go
@@ -54,6 +54,13 @@ func resourceApplicationPassword() *schema.Resource {
 				ValidateFunc: validate.UUID,
 			},
 
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+
 			"value": {
 				Type:         schema.TypeString,
 				Required:     true,
@@ -173,6 +180,7 @@ func resourceApplicationPasswordRead(d *schema.ResourceData, meta interface{}) e
 	d.Set("application_object_id", id.ObjectId)
 	d.Set("application_id", id.ObjectId) //todo remove in 2.0
 	d.Set("key_id", id.KeyId)
+	d.Set("description", credential.CustomKeyIdentifier)
 
 	if endDate := credential.EndDate; endDate != nil {
 		d.Set("end_date", endDate.Format(time.RFC3339))

--- a/azuread/resource_application_password.go
+++ b/azuread/resource_application_password.go
@@ -180,7 +180,10 @@ func resourceApplicationPasswordRead(d *schema.ResourceData, meta interface{}) e
 	d.Set("application_object_id", id.ObjectId)
 	d.Set("application_id", id.ObjectId) //todo remove in 2.0
 	d.Set("key_id", id.KeyId)
-	d.Set("description", string(*credential.CustomKeyIdentifier))
+
+	if description := credential.CustomKeyIdentifier; description != nil {
+		d.Set("description", string(*description))
+	}
 
 	if endDate := credential.EndDate; endDate != nil {
 		d.Set("end_date", endDate.Format(time.RFC3339))

--- a/azuread/resource_application_password_test.go
+++ b/azuread/resource_application_password_test.go
@@ -178,6 +178,29 @@ func TestAccAzureADApplicationPassword_customKeyId(t *testing.T) {
 	})
 }
 
+func TestAccAzureADApplicationPassword_description(t *testing.T) {
+	resourceName := "azuread_application_password.test"
+	applicationId := uuid.New().String()
+	value := uuid.New().String()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckADApplicationPasswordCheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccADApplicationPassword_description(applicationId, value),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckADApplicationPasswordExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "start_date"),
+					resource.TestCheckResourceAttr(resourceName, "description", "terraform"),
+					resource.TestCheckResourceAttr(resourceName, "end_date", "2099-01-01T01:02:03Z"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAzureADApplicationPassword_relativeEndDate(t *testing.T) {
 	resourceName := "azuread_application_password.test"
 	applicationId := uuid.New().String()
@@ -259,6 +282,19 @@ resource "azuread_application_password" "test" {
   end_date              = "2099-01-01T01:02:03Z"
 }
 `, testAccADApplicationPassword_template(applicationId), keyId, value)
+}
+
+func testAccADApplicationPassword_description(applicationId, value string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azuread_application_password" "test" {
+  application_object_id = "${azuread_application.test.id}"
+  description           = "terraform"
+  value                 = "%s"
+  end_date              = "2099-01-01T01:02:03Z"
+}
+`, testAccADApplicationPassword_template(applicationId), value)
 }
 
 func testAccADApplicationPassword_relativeEndDate(applicationId, value string) string {

--- a/azuread/resource_service_principal_password.go
+++ b/azuread/resource_service_principal_password.go
@@ -104,6 +104,7 @@ func resourceServicePrincipalPasswordRead(d *schema.ResourceData, meta interface
 	// value is available in the SDK but isn't returned from the API
 	d.Set("key_id", credential.KeyID)
 	d.Set("service_principal_id", id.ObjectId)
+	d.Set("description", credential.CustomKeyIdentifier)
 
 	if endDate := credential.EndDate; endDate != nil {
 		d.Set("end_date", endDate.Format(time.RFC3339))

--- a/azuread/resource_service_principal_password.go
+++ b/azuread/resource_service_principal_password.go
@@ -104,7 +104,7 @@ func resourceServicePrincipalPasswordRead(d *schema.ResourceData, meta interface
 	// value is available in the SDK but isn't returned from the API
 	d.Set("key_id", credential.KeyID)
 	d.Set("service_principal_id", id.ObjectId)
-	d.Set("description", credential.CustomKeyIdentifier)
+	d.Set("description", string(*credential.CustomKeyIdentifier))
 
 	if endDate := credential.EndDate; endDate != nil {
 		d.Set("end_date", endDate.Format(time.RFC3339))

--- a/azuread/resource_service_principal_password.go
+++ b/azuread/resource_service_principal_password.go
@@ -104,7 +104,10 @@ func resourceServicePrincipalPasswordRead(d *schema.ResourceData, meta interface
 	// value is available in the SDK but isn't returned from the API
 	d.Set("key_id", credential.KeyID)
 	d.Set("service_principal_id", id.ObjectId)
-	d.Set("description", string(*credential.CustomKeyIdentifier))
+
+	if description := credential.CustomKeyIdentifier; description != nil {
+		d.Set("description", string(*description))
+	}
 
 	if endDate := credential.EndDate; endDate != nil {
 		d.Set("end_date", endDate.Format(time.RFC3339))

--- a/azuread/resource_service_principal_password_test.go
+++ b/azuread/resource_service_principal_password_test.go
@@ -156,6 +156,30 @@ func TestAccAzureADServicePrincipalPassword_customKeyId(t *testing.T) {
 	})
 }
 
+func TestAccAzureADServicePrincipalPassword_description(t *testing.T) {
+	resourceName := "azuread_service_principal_password.test"
+	applicationId := uuid.New().String()
+	value := uuid.New().String()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckADServicePrincipalPasswordCheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccADServicePrincipalPassword_description(applicationId, value),
+				Check: resource.ComposeTestCheckFunc(
+					// can't assert on Value since it's not returned
+					testCheckADServicePrincipalPasswordExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "start_date"),
+					resource.TestCheckResourceAttr(resourceName, "description", "terraform"),
+					resource.TestCheckResourceAttr(resourceName, "end_date", "2099-01-01T01:02:03Z"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAzureADServicePrincipalPassword_relativeEndDate(t *testing.T) {
 	resourceName := "azuread_service_principal_password.test"
 	applicationId := uuid.New().String()
@@ -229,6 +253,19 @@ resource "azuread_service_principal_password" "test" {
   end_date             = "2099-01-01T01:02:03Z"
 }
 `, testAccADServicePrincipalPassword_template(applicationId), keyId, value)
+}
+
+func testAccADServicePrincipalPassword_description(applicationId, value string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azuread_service_principal_password" "test" {
+  service_principal_id = "${azuread_service_principal.test.id}"
+  description          = "terraform"
+  value                = "%s"
+  end_date             = "2099-01-01T01:02:03Z"
+}
+`, testAccADServicePrincipalPassword_template(applicationId), value)
 }
 
 func testAccADServicePrincipalPassword_relativeEndDate(applicationId, value string) string {

--- a/website/docs/r/application_password.html.markdown
+++ b/website/docs/r/application_password.html.markdown
@@ -27,6 +27,7 @@ resource "azuread_application" "example" {
 
 resource "azuread_application_password" "example" {
   application_id = "${azuread_application.example.id}"
+  description    = "My managed password"
   value          = "VT=uSgbTanZhyz@%nL9Hpd+Tfay_MRV#"
   end_date       = "2099-01-01T01:02:03Z"
 }
@@ -38,7 +39,9 @@ The following arguments are supported:
 
 * `application_object_id` - (Required) The Object ID of the Application for which this password should be created. Changing this field forces a new resource to be created.
 
-* `value` - (Required) The Password for this Application .
+* `value` - (Required) The Password for this Application.
+
+* `description` - (Optional) A description for the Password.
 
 * `end_date` - (Optional) The End Date which the Password is valid until, formatted as a RFC3339 date string (e.g. `2018-01-01T01:02:03Z`). Changing this field forces a new resource to be created.
 

--- a/website/docs/r/application_password.html.markdown
+++ b/website/docs/r/application_password.html.markdown
@@ -43,6 +43,8 @@ The following arguments are supported:
 
 * `description` - (Optional) A description for the Password.
 
+-> **NOTE:** `description` maps to the `CustomKeyIdentifier` property of the `PasswordCredentials` API resource.
+
 * `end_date` - (Optional) The End Date which the Password is valid until, formatted as a RFC3339 date string (e.g. `2018-01-01T01:02:03Z`). Changing this field forces a new resource to be created.
 
 * `end_date_relative` - (Optional) A relative duration for which the Password is valid until, for example `240h` (10 days) or `2400h30m`. Changing this field forces a new resource to be created.

--- a/website/docs/r/service_principal_password.html.markdown
+++ b/website/docs/r/service_principal_password.html.markdown
@@ -47,6 +47,8 @@ The following arguments are supported:
 
 * `description` - (Optional) A description for the Password.
 
+-> **NOTE:** `description` maps to the `CustomKeyIdentifier` property of the `PasswordCredentials` API resource.
+
 * `end_date` - (Optional) The End Date which the Password is valid until, formatted as a RFC3339 date string (e.g. `2018-01-01T01:02:03Z`). Changing this field forces a new resource to be created.
 
 * `end_date_relative` - (Optional) A relative duration for which the Password is valid until, for example `240h` (10 days) or `2400h30m`. Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h". Changing this field forces a new resource to be created.

--- a/website/docs/r/service_principal_password.html.markdown
+++ b/website/docs/r/service_principal_password.html.markdown
@@ -31,6 +31,7 @@ resource "azuread_service_principal" "example" {
 
 resource "azuread_service_principal_password" "example" {
   service_principal_id = "${azuread_service_principal.example.id}"
+  description          = "My managed password"
   value                = "VT=uSgbTanZhyz@%nL9Hpd+Tfay_MRV#"
   end_date             = "2099-01-01T01:02:03Z"
 }
@@ -43,6 +44,8 @@ The following arguments are supported:
 * `service_principal_id` - (Required) The ID of the Service Principal for which this password should be created. Changing this field forces a new resource to be created.
 
 * `value` - (Required) The Password for this Service Principal.
+
+* `description` - (Optional) A description for the Password.
 
 * `end_date` - (Optional) The End Date which the Password is valid until, formatted as a RFC3339 date string (e.g. `2018-01-01T01:02:03Z`). Changing this field forces a new resource to be created.
 


### PR DESCRIPTION
This is the same description field yielded by the corresponding Portal page. Although the API exposes it as `customKeyIdentifier` this term doesn't seem to be exposed to users.

Fixes: #95