### PR TITLE
Allow for graceful handling of errored users within users data source

### DIFF
--- a/azuread/data_users.go
+++ b/azuread/data_users.go
@@ -26,8 +26,8 @@ func dataUsers() *schema.Resource {
 			"object_ids": {
 				Type:         schema.TypeList,
 				Optional:     true,
-				Computed:      true,
-				ConflictsWith: []string{"user_principal_names"},
+				Computed:     true,
+				ExactlyOneOf: []string{"object_ids", "user_principal_names", "mail_nicknames"},
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
 					ValidateFunc: validate.UUID,
@@ -37,8 +37,8 @@ func dataUsers() *schema.Resource {
 			"user_principal_names": {
 				Type:         schema.TypeList,
 				Optional:     true,
-				Computed:      true,
-				ConflictsWith: []string{"object_ids"},
+				Computed:     true,
+				ExactlyOneOf: []string{"object_ids", "user_principal_names", "mail_nicknames"},
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
 					ValidateFunc: validate.NoEmptyStrings,
@@ -46,10 +46,10 @@ func dataUsers() *schema.Resource {
 			},
 
 			"mail_nicknames": {
-				Type:          schema.TypeList,
-				Optional:      true,
-				Computed:      true,
-				ConflictsWith: []string{"object_ids", "user_principal_names"},
+				Type:         schema.TypeList,
+				Optional:     true,
+				Computed:     true,
+				ExactlyOneOf: []string{"object_ids", "user_principal_names", "mail_nicknames"},
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
 					ValidateFunc: validate.NoEmptyStrings,

--- a/azuread/data_users.go
+++ b/azuread/data_users.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/graphrbac/1.6/graphrbac"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 
+	"github.com/terraform-providers/terraform-provider-azuread/azuread/helpers/ar"
 	"github.com/terraform-providers/terraform-provider-azuread/azuread/helpers/graph"
 	"github.com/terraform-providers/terraform-provider-azuread/azuread/helpers/validate"
 )
@@ -23,8 +24,8 @@ func dataUsers() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"object_ids": {
-				Type:          schema.TypeList,
-				Optional:      true,
+				Type:         schema.TypeList,
+				Optional:     true,
 				Computed:      true,
 				ConflictsWith: []string{"user_principal_names"},
 				Elem: &schema.Schema{
@@ -34,8 +35,8 @@ func dataUsers() *schema.Resource {
 			},
 
 			"user_principal_names": {
-				Type:          schema.TypeList,
-				Optional:      true,
+				Type:         schema.TypeList,
+				Optional:     true,
 				Computed:      true,
 				ConflictsWith: []string{"object_ids"},
 				Elem: &schema.Schema{
@@ -54,6 +55,70 @@ func dataUsers() *schema.Resource {
 					ValidateFunc: validate.NoEmptyStrings,
 				},
 			},
+
+			"ignore_missing": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
+			"users": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"account_enabled": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+
+						"display_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"immutable_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"mail": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"mail_nickname": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"object_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"onpremises_sam_account_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"onpremises_user_principal_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"usage_location": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"user_principal_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -62,54 +127,83 @@ func dataSourceUsersRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ArmClient).usersClient
 	ctx := meta.(*ArmClient).StopContext
 
-	var users []graphrbac.User
+	var users []*graphrbac.User
 	expectedCount := 0
 
+	ignoreMissing := d.Get("ignore_missing").(bool)
 	if upns, ok := d.Get("user_principal_names").([]interface{}); ok && len(upns) > 0 {
 		expectedCount = len(upns)
 		for _, v := range upns {
-			resp, err := client.Get(ctx, v.(string))
+			u, err := client.Get(ctx, v.(string))
 			if err != nil {
+				if ignoreMissing && ar.ResponseWasNotFound(u.Response) {
+					break
+				}
 				return fmt.Errorf("Error making Read request on AzureAD User with ID %q: %+v", v.(string), err)
 			}
-
-			users = append(users, resp)
+			users = append(users, &u)
 		}
 	} else if oids, ok := d.Get("object_ids").([]interface{}); ok && len(oids) > 0 {
 		expectedCount = len(oids)
 		for _, v := range oids {
 			u, err := graph.UserGetByObjectId(&client, ctx, v.(string))
 			if err != nil {
+				if ignoreMissing && ar.ResponseWasNotFound(u.Response) {
+					break
+				}
 				return fmt.Errorf("Error finding Azure AD User with object ID %q: %+v", v.(string), err)
 			}
-			users = append(users, *u)
+			users = append(users, u)
 		}
 	} else if mailNicknames, ok := d.Get("mail_nicknames").([]interface{}); ok && len(mailNicknames) > 0 {
 		expectedCount = len(mailNicknames)
 		for _, v := range mailNicknames {
 			u, err := graph.UserGetByMailNickname(&client, ctx, v.(string))
 			if err != nil {
+				if ignoreMissing && ar.ResponseWasNotFound(u.Response) {
+					break
+				}
 				return fmt.Errorf("Error finding Azure AD User with email alias %q: %+v", v.(string), err)
 			}
-			users = append(users, *u)
+			users = append(users, u)
 		}
 	}
 
-	if len(users) != expectedCount {
+	if !ignoreMissing && len(users) != expectedCount {
 		return fmt.Errorf("Unexpected number of users returned (%d != %d)", len(users), expectedCount)
+	}
+
+	if ignoreMissing && len(users) == 0 {
+		return fmt.Errorf("No users were returned")
 	}
 
 	upns := make([]string, 0, len(users))
 	oids := make([]string, 0, len(users))
 	mailNicknames := make([]string, 0, len(users))
+	var userList []map[string]interface{}
 	for _, u := range users {
 		if u.ObjectID == nil || u.UserPrincipalName == nil {
 			return fmt.Errorf("User with nil ObjectId or UPN was found: %v", u)
 		}
 
-		oids = append(oids, *u.ObjectID)
-		upns = append(upns, *u.UserPrincipalName)
-		mailNicknames = append(mailNicknames, *u.MailNickname)
+		if u.ObjectID != nil || u.UserPrincipalName != nil {
+			oids = append(oids, *u.ObjectID)
+			upns = append(upns, *u.UserPrincipalName)
+			mailNicknames = append(mailNicknames, *u.MailNickname)
+
+			user := make(map[string]interface{})
+			user["account_enabled"] = u.AccountEnabled
+			user["display_name"] = u.DisplayName
+			user["immutable_id"] = u.ImmutableID
+			user["mail"] = u.Mail
+			user["mail_nickname"] = u.MailNickname
+			user["object_id"] = u.ObjectID
+			user["onpremises_sam_account_name"] = u.AdditionalProperties["onPremisesSamAccountName"]
+			user["onpremises_user_principal_name"] = u.AdditionalProperties["onPremisesUserPrincipalName"]
+			user["usage_location"] = u.UsageLocation
+			user["user_principal_name"] = u.UserPrincipalName
+			userList = append(userList, user)
+		}
 	}
 
 	h := sha1.New()
@@ -121,5 +215,7 @@ func dataSourceUsersRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("object_ids", oids)
 	d.Set("user_principal_names", upns)
 	d.Set("mail_nicknames", mailNicknames)
+	d.Set("users", userList)
+
 	return nil
 }

--- a/azuread/data_users_test.go
+++ b/azuread/data_users_test.go
@@ -24,6 +24,7 @@ func TestAccAzureADUsersDataSource_byUserPrincipalNames(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dsn, "user_principal_names.#", "2"),
 					resource.TestCheckResourceAttr(dsn, "object_ids.#", "2"),
+					resource.TestCheckResourceAttr(dsn, "users.#", "2"),
 				),
 			},
 		},
@@ -44,6 +45,7 @@ func TestAccAzureADUsersDataSource_byObjectIds(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dsn, "user_principal_names.#", "2"),
 					resource.TestCheckResourceAttr(dsn, "object_ids.#", "2"),
+					resource.TestCheckResourceAttr(dsn, "users.#", "2"),
 				),
 			},
 		},
@@ -65,6 +67,7 @@ func TestAccAzureADUsersDataSource_byMailNicknames(t *testing.T) {
 					resource.TestCheckResourceAttr(dsn, "user_principal_names.#", "2"),
 					resource.TestCheckResourceAttr(dsn, "object_ids.#", "2"),
 					resource.TestCheckResourceAttr(dsn, "mail_nicknames.#", "2"),
+					resource.TestCheckResourceAttr(dsn, "users.#", "2"),
 				),
 			},
 		},
@@ -84,6 +87,28 @@ func TestAccAzureADUsersDataSource_noNames(t *testing.T) {
 					resource.TestCheckResourceAttr(dsn, "user_principal_names.#", "0"),
 					resource.TestCheckResourceAttr(dsn, "object_ids.#", "0"),
 					resource.TestCheckResourceAttr(dsn, "mail_nicknames.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureADUsersDataSource_ignoreMissing(t *testing.T) {
+	dsn := "data.azuread_users.test"
+	id := tf.AccRandTimeInt()
+	password := "p@$$wR2" + acctest.RandStringFromCharSet(7, acctest.CharSetAlphaNum)
+	ri := tf.AccRandTimeInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureADUsersDataSource_ignoreMissing(id, password, ri),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dsn, "user_principal_names.#", "3"),
+					resource.TestCheckResourceAttr(dsn, "object_ids.#", "3"),
+					resource.TestCheckResourceAttr(dsn, "users.#", "3"),
 				),
 			},
 		},
@@ -126,4 +151,21 @@ data "azuread_users" "test" {
   user_principal_names = []
 }
 `
+}
+
+func testAccAzureADUsersDataSource_ignoreMissing(id int, password string, ri int) string {
+	return fmt.Sprintf(`
+%s
+
+data "azuread_users" "test" {
+  ignore_missing = true
+
+  user_principal_names = [
+    azuread_user.testA.user_principal_name,
+    azuread_user.testB.user_principal_name,
+    azuread_user.testC.user_principal_name,
+    "not-a-real-user-%d${data.azuread_domains.tenant_domain.domains.0.domain_name}",
+  ]
+}
+`, testAccADUser_threeUsersABC(id, password), ri)
 }

--- a/website/docs/d/users.html.markdown
+++ b/website/docs/d/users.html.markdown
@@ -54,7 +54,6 @@ The `user` object consists of:
 * `display_name` - The Display Name of the Azure AD User.
 * `mail` - The primary email address of the Azure AD User.
 * `mail_nickname` - The email alias of the Azure AD User.
-* `mail_nickname` - The email alias of the Azure AD User.
 * `onpremises_sam_account_name` - The on premise sam account name of the Azure AD User.
 * `onpremises_user_principal_name` - The on premise user principal name of the Azure AD User.
 * `usage_location` - The usage location of the Azure AD User.

--- a/website/docs/d/users.html.markdown
+++ b/website/docs/d/users.html.markdown
@@ -33,6 +33,8 @@ The following arguments are supported:
 
 -> **NOTE:** Either `user_principal_names`, `object_ids` or `mail_nicknames` should be specified. These _may_ be specified as an empty list, in which case no results will be returned.
 
+* `ignore_missing` - (Optional) Ignore missing users and return users that were found. The data source will still fail if no users are found. Defaults to false.
+
 ## Attributes Reference
 
 The following attributes are exported:
@@ -40,3 +42,20 @@ The following attributes are exported:
 * `object_ids` - The Object IDs of the Azure AD Users.
 * `user_principal_names` - The User Principal Names of the Azure AD Users.
 * `mail_nicknames` - The email aliases of the Azure AD Users.
+* `users` - An Array of Azure AD Users. Each `user` object consists of the fields documented below.
+
+___
+
+The `user` object consists of:
+
+* `id` - The Object ID of the Azure AD User.
+* `user_principal_name` - The User Principal Name of the Azure AD User.
+* `account_enabled` - `True` if the account is enabled; otherwise `False`.
+* `display_name` - The Display Name of the Azure AD User.
+* `mail` - The primary email address of the Azure AD User.
+* `mail_nickname` - The email alias of the Azure AD User.
+* `mail_nickname` - The email alias of the Azure AD User.
+* `onpremises_sam_account_name` - The on premise sam account name of the Azure AD User.
+* `onpremises_user_principal_name` - The on premise user principal name of the Azure AD User.
+* `usage_location` - The usage location of the Azure AD User.
+* `immutable_id` - The value used to associate an on-premises Active Directory user account with their Azure AD user object.


### PR DESCRIPTION
Return all user data in `users` parameter aray

* Add users parameter - an array of users which mirrors that of the user
data source. This allows for additional validation of users - such as
checking whether the account is enabled.

Allow user lookup to gracefully fail

* Add graceful_errors parameter to allow user lookup to gracefully fail.
This allows only users which were successfully looked up to return. The
data source will still result in an error if no users were returned.

Documentation updated to include the two new parameters.
 
Add missing MailNickname validation logic