### PR TITLE
data.azuread_groups: support empty list for names/object_ids arguments

### DIFF
--- a/azuread/data_groups.go
+++ b/azuread/data_groups.go
@@ -26,7 +26,6 @@ func dataGroups() *schema.Resource {
 				Type:          schema.TypeList,
 				Optional:      true,
 				Computed:      true,
-				MinItems:      1,
 				ConflictsWith: []string{"names"},
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
@@ -38,7 +37,6 @@ func dataGroups() *schema.Resource {
 				Type:          schema.TypeList,
 				Optional:      true,
 				Computed:      true,
-				MinItems:      1,
 				ConflictsWith: []string{"object_ids"},
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
@@ -75,8 +73,6 @@ func dataSourceGroupsRead(d *schema.ResourceData, meta interface{}) error {
 
 			groups = append(groups, resp)
 		}
-	} else {
-		return fmt.Errorf("one of `object_ids` or `names` must be supplied")
 	}
 
 	if len(groups) != expectedCount {

--- a/azuread/data_groups_test.go
+++ b/azuread/data_groups_test.go
@@ -47,6 +47,24 @@ func TestAccAzureADGroupsDataSource_byObjectIds(t *testing.T) {
 	})
 }
 
+func TestAccAzureADGroupsDataSource_noNames(t *testing.T) {
+	dsn := "data.azuread_groups.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureADGroupsDataSource_noNames(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dsn, "names.#", "0"),
+					resource.TestCheckResourceAttr(dsn, "object_ids.#", "0"),
+				),
+			},
+		},
+	})
+}
+
 func testAccAzureADGroup_multiple(id int) string {
 	return fmt.Sprintf(`
 resource "azuread_group" "testA" {
@@ -79,4 +97,11 @@ data "azuread_groups" "test" {
   object_ids = ["${azuread_group.testA.object_id}", "${azuread_group.testB.object_id}"]
 }
 `, testAccAzureADGroup_multiple(id))
+}
+func testAccAzureADGroupsDataSource_noNames() string {
+	return `
+data "azuread_groups" "test" {
+  names = []
+}
+`
 }

--- a/website/docs/d/groups.html.markdown
+++ b/website/docs/d/groups.html.markdown
@@ -29,6 +29,8 @@ The following arguments are supported:
 
 * `object_ids` - (Optional) The Object IDs of the Azure AD Groups.
 
+-> **NOTE:** Either `names` or `object_ids` should be specified. Either of these _may_ be specified as an empty list, in which case no results will be returned.
+
 ## Attributes Reference
 
 The following attributes are exported:

--- a/website/docs/d/groups.html.markdown
+++ b/website/docs/d/groups.html.markdown
@@ -25,11 +25,9 @@ data "azuread_groups" "groups" {
 
 The following arguments are supported:
 
-* `names` - (optional) The Display Names of the Azure AD Groups.
+* `names` - (Optional) The Display Names of the Azure AD Groups.
 
 * `object_ids` - (Optional) The Object IDs of the Azure AD Groups.
-
--> **NOTE:** Either `names` or `object_ids` must be specified.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Support empty lists for the `names` and `object_ids` arguments, in which case no results will be returned. Aims to support the use case of the data source in a module where the input variable may be empty.

Thanks to @jpreese for the suggestion and implementation

Replaces: #231 