### PR TITLE
 data.azuread_users: support empty search lists

### DIFF
--- a/azuread/data_users.go
+++ b/azuread/data_users.go
@@ -26,7 +26,6 @@ func dataUsers() *schema.Resource {
 				Type:          schema.TypeList,
 				Optional:      true,
 				Computed:      true,
-				MinItems:      1,
 				ConflictsWith: []string{"user_principal_names"},
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
@@ -38,7 +37,6 @@ func dataUsers() *schema.Resource {
 				Type:          schema.TypeList,
 				Optional:      true,
 				Computed:      true,
-				MinItems:      1,
 				ConflictsWith: []string{"object_ids"},
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
@@ -50,7 +48,6 @@ func dataUsers() *schema.Resource {
 				Type:          schema.TypeList,
 				Optional:      true,
 				Computed:      true,
-				MinItems:      1,
 				ConflictsWith: []string{"object_ids", "user_principal_names"},
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
@@ -96,8 +93,6 @@ func dataSourceUsersRead(d *schema.ResourceData, meta interface{}) error {
 			}
 			users = append(users, *u)
 		}
-	} else {
-		return fmt.Errorf("one of `object_ids`, `user_principal_names` or `mail_nicknames` must be supplied")
 	}
 
 	if len(users) != expectedCount {

--- a/azuread/data_users_test.go
+++ b/azuread/data_users_test.go
@@ -71,6 +71,25 @@ func TestAccAzureADUsersDataSource_byMailNicknames(t *testing.T) {
 	})
 }
 
+func TestAccAzureADUsersDataSource_noNames(t *testing.T) {
+	dsn := "data.azuread_users.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureADUsersDataSource_noNames(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dsn, "user_principal_names.#", "0"),
+					resource.TestCheckResourceAttr(dsn, "object_ids.#", "0"),
+					resource.TestCheckResourceAttr(dsn, "mail_nicknames.#", "0"),
+				),
+			},
+		},
+	})
+}
+
 func testAccAzureADUsersDataSource_byUserPrincipalNames(id int, password string) string {
 	return fmt.Sprintf(`
 %s
@@ -99,4 +118,12 @@ data "azuread_users" "test" {
   mail_nicknames = ["${azuread_user.testA.mail_nickname}", "${azuread_user.testB.mail_nickname}"]
 }
 `, testAccADUser_threeUsersABC(id, password))
+}
+
+func testAccAzureADUsersDataSource_noNames() string {
+	return `
+data "azuread_users" "test" {
+  user_principal_names = []
+}
+`
 }

--- a/website/docs/d/users.html.markdown
+++ b/website/docs/d/users.html.markdown
@@ -25,13 +25,13 @@ data "azuread_users" "users" {
 
 The following arguments are supported:
 
-* `user_principal_names` - (optional) The User Principal Names of the Azure AD Users.
+* `user_principal_names` - (Optional) The User Principal Names of the Azure AD Users.
 
 * `object_ids` - (Optional) The Object IDs of the Azure AD Users.
 
 * `mail_nicknames` - (Optional) The email aliases of the Azure AD Users.
 
--> **NOTE:** Either `user_principal_names`, `object_ids` or `mail_nicknames` must be specified.
+-> **NOTE:** Either `user_principal_names`, `object_ids` or `mail_nicknames` should be specified. These _may_ be specified as an empty list, in which case no results will be returned.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Support empty lists for the `user_principal_names`, `object_ids` and `mail_nicknames` arguments, in which case no results will be returned. Aims to improve reusability where the data source is used in a module where the input variable(s) may be empty.