### PR TITLE
End date validation for azuread_application_password / azuread_service_principal_password

### DIFF
--- a/azuread/helpers/graph/credentials.go
+++ b/azuread/helpers/graph/credentials.go
@@ -63,7 +63,7 @@ func PasswordResourceSchema(object_type string) map[string]*schema.Schema {
 			Optional:      true,
 			Computed:      true,
 			ForceNew:      true,
-			ConflictsWith: []string{"end_date_relative"},
+			ExactlyOneOf:  []string{"end_date_relative"},
 			ValidateFunc:  validation.IsRFC3339Time,
 		},
 
@@ -71,7 +71,7 @@ func PasswordResourceSchema(object_type string) map[string]*schema.Schema {
 			Type:          schema.TypeString,
 			Optional:      true,
 			ForceNew:      true,
-			ConflictsWith: []string{"end_date"},
+			ExactlyOneOf:  []string{"end_date"},
 			ValidateFunc:  validate.NoEmptyStrings,
 		},
 	}

--- a/azuread/helpers/graph/credentials.go
+++ b/azuread/helpers/graph/credentials.go
@@ -59,20 +59,20 @@ func PasswordResourceSchema(object_type string) map[string]*schema.Schema {
 		},
 
 		"end_date": {
-			Type:          schema.TypeString,
-			Optional:      true,
-			Computed:      true,
-			ForceNew:      true,
-			ExactlyOneOf:  []string{"end_date_relative"},
-			ValidateFunc:  validation.IsRFC3339Time,
+			Type:         schema.TypeString,
+			Optional:     true,
+			Computed:     true,
+			ForceNew:     true,
+			ExactlyOneOf: []string{"end_date_relative"},
+			ValidateFunc: validation.IsRFC3339Time,
 		},
 
 		"end_date_relative": {
-			Type:          schema.TypeString,
-			Optional:      true,
-			ForceNew:      true,
-			ExactlyOneOf:  []string{"end_date"},
-			ValidateFunc:  validate.NoEmptyStrings,
+			Type:         schema.TypeString,
+			Optional:     true,
+			ForceNew:     true,
+			ExactlyOneOf: []string{"end_date"},
+			ValidateFunc: validate.NoEmptyStrings,
 		},
 	}
 }

--- a/website/docs/r/application_password.html.markdown
+++ b/website/docs/r/application_password.html.markdown
@@ -26,10 +26,10 @@ resource "azuread_application" "example" {
 }
 
 resource "azuread_application_password" "example" {
-  application_id = "${azuread_application.example.id}"
-  description    = "My managed password"
-  value          = "VT=uSgbTanZhyz@%nL9Hpd+Tfay_MRV#"
-  end_date       = "2099-01-01T01:02:03Z"
+  application_object_id = "${azuread_application.example.id}"
+  description           = "My managed password"
+  value                 = "VT=uSgbTanZhyz@%nL9Hpd+Tfay_MRV#"
+  end_date              = "2099-01-01T01:02:03Z"
 }
 ```
 


### PR DESCRIPTION
As per API, perform validation at plan time. Also fix up usage example for `azuread_application_password`.

```
azuread_application_password.test: Creating...
azuread_service_principal_password.test: Creating...

Error: Error generating Service Principal Credentials for Object ID "11b9ba63-8800-4644-aa21-a427ebf176a8": one of `end_date` or `end_date_relative` must be specified

  on sp.tf line 5, in resource "azuread_service_principal_password" "test":
   5: resource "azuread_service_principal_password" "test" {

Error: Error generating Application Credentials for Object ID "cf34834b-b0ca-490a-9037-fe1002906768": one of `end_date` or `end_date_relative` must be specified

  on sp.tf line 11, in resource "azuread_application_password" "test":
  11: resource "azuread_application_password" "test" {
```

Fixes: #223