### PR TITLE
New ID format for azuread_application_certificate, azuread_application_password, azuread_service_principal_certificate, azuread_service_principal_password

### DIFF
--- a/azuread/resource_application.go
+++ b/azuread/resource_application.go
@@ -745,6 +745,12 @@ func expandADApplicationOptionalClaim(in []interface{}) *[]graphrbac.OptionalCla
 }
 
 func flattenADApplicationOptionalClaims(in *graphrbac.OptionalClaims) interface{} {
+	var result []map[string]interface{}
+
+	if in == nil {
+		return result
+	}
+
 	optionalClaims := make(map[string]interface{})
 	if claims := flattenADApplicationOptionalClaimsList(in.AccessToken); len(claims) > 0 {
 		optionalClaims["access_token"] = claims
@@ -756,7 +762,6 @@ func flattenADApplicationOptionalClaims(in *graphrbac.OptionalClaims) interface{
 	//if claims := flattenADApplicationOptionalClaimsList(in.SamlToken); len(claims) > 0 {
 	//	optionalClaims["saml_token"] = claims
 	//}
-	var result []map[string]interface{}
 	if len(optionalClaims) == 0 {
 		return result
 	}

--- a/azuread/resource_application_certificate.go
+++ b/azuread/resource_application_certificate.go
@@ -37,7 +37,7 @@ func resourceApplicationCertificateCreate(d *schema.ResourceData, meta interface
 	if err != nil {
 		return fmt.Errorf("generating certificate credentials for object ID %q: %+v", objectId, err)
 	}
-	id := graph.CredentialIdFrom(objectId, *cred.KeyID)
+	id := graph.CredentialIdFrom(objectId, "certificate", *cred.KeyID)
 
 	tf.LockByName(resourceApplicationName, id.ObjectId)
 	defer tf.UnlockByName(resourceApplicationName, id.ObjectId)

--- a/azuread/resource_application_password.go
+++ b/azuread/resource_application_password.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/graphrbac/1.6/graphrbac"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+
 	"github.com/terraform-providers/terraform-provider-azuread/azuread/helpers/ar"
 	"github.com/terraform-providers/terraform-provider-azuread/azuread/helpers/graph"
 	"github.com/terraform-providers/terraform-provider-azuread/azuread/helpers/tf"

--- a/azuread/resource_application_password_test.go
+++ b/azuread/resource_application_password_test.go
@@ -97,6 +97,12 @@ func TestAccAzureADApplicationPassword_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "end_date", "2099-01-01T01:02:03Z"),
 				),
 			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"value"},
+			},
 		},
 	})
 }
@@ -120,6 +126,12 @@ func TestAccAzureADApplicationPassword_basicOld(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "key_id"),
 					resource.TestCheckResourceAttr(resourceName, "end_date", "2099-01-01T01:02:03Z"),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"value"},
 			},
 		},
 	})
@@ -174,6 +186,12 @@ func TestAccAzureADApplicationPassword_customKeyId(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "end_date", "2099-01-01T01:02:03Z"),
 				),
 			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"value"},
+			},
 		},
 	})
 }
@@ -196,6 +214,12 @@ func TestAccAzureADApplicationPassword_description(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "description", "terraform"),
 					resource.TestCheckResourceAttr(resourceName, "end_date", "2099-01-01T01:02:03Z"),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"value"},
 			},
 		},
 	})
@@ -220,6 +244,12 @@ func TestAccAzureADApplicationPassword_relativeEndDate(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "key_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "end_date"),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"end_date_relative", "value"},
 			},
 		},
 	})

--- a/azuread/resource_service_principal_certificate.go
+++ b/azuread/resource_service_principal_certificate.go
@@ -37,7 +37,7 @@ func resourceServicePrincipalCertificateCreate(d *schema.ResourceData, meta inte
 	if err != nil {
 		return fmt.Errorf("generating certificate credentials for object ID %q: %+v", objectId, err)
 	}
-	id := graph.CredentialIdFrom(objectId, *cred.KeyID)
+	id := graph.CredentialIdFrom(objectId, "certificate", *cred.KeyID)
 
 	tf.LockByName(servicePrincipalResourceName, id.ObjectId)
 	defer tf.UnlockByName(servicePrincipalResourceName, id.ObjectId)

--- a/azuread/resource_service_principal_password_test.go
+++ b/azuread/resource_service_principal_password_test.go
@@ -98,6 +98,12 @@ func TestAccAzureADServicePrincipalPassword_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "end_date", "2099-01-01T01:02:03Z"),
 				),
 			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"value"},
+			},
 		},
 	})
 }
@@ -152,6 +158,12 @@ func TestAccAzureADServicePrincipalPassword_customKeyId(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "end_date", "2099-01-01T01:02:03Z"),
 				),
 			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"value"},
+			},
 		},
 	})
 }
@@ -176,6 +188,12 @@ func TestAccAzureADServicePrincipalPassword_description(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "end_date", "2099-01-01T01:02:03Z"),
 				),
 			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"value"},
+			},
 		},
 	})
 }
@@ -199,6 +217,12 @@ func TestAccAzureADServicePrincipalPassword_relativeEndDate(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "key_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "end_date"),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"end_date_relative", "value"},
 			},
 		},
 	})

--- a/website/docs/r/application_certificate.html.markdown
+++ b/website/docs/r/application_certificate.html.markdown
@@ -57,10 +57,10 @@ The following attributes are exported:
 
 ## Import
 
-Certificates can be imported using the `object id` of an Application, e.g.
+Certificates can be imported using the `object id` of an Application and the `key id` of the certificate, e.g.
 
 ```shell
-terraform import azuread_application_certificate.test 00000000-0000-0000-0000-000000000000/11111111-1111-1111-1111-111111111111
+terraform import azuread_application_certificate.test 00000000-0000-0000-0000-000000000000/certificate/11111111-1111-1111-1111-111111111111
 ```
 
--> **NOTE:** This ID format is unique to Terraform and is composed of the Application's Object ID and the Certificate's Key ID in the format `{ObjectId}/{CertificateKeyId}`.
+-> **NOTE:** This ID format is unique to Terraform and is composed of the Application's Object ID, the string "certificate" and the Certificate's Key ID in the format `{ObjectId}/certificate/{CertificateKeyId}`.

--- a/website/docs/r/application_password.html.markdown
+++ b/website/docs/r/application_password.html.markdown
@@ -64,10 +64,10 @@ The following attributes are exported:
 
 ## Import
 
-Passwords can be imported using the `object id` of an Application, e.g.
+Passwords can be imported using the `object id` of an Application and the `key id` of the password, e.g.
 
 ```shell
-terraform import azuread_application_password.test 00000000-0000-0000-0000-000000000000/11111111-1111-1111-1111-111111111111
+terraform import azuread_application_password.test 00000000-0000-0000-0000-000000000000/password/11111111-1111-1111-1111-111111111111
 ```
 
--> **NOTE:** This ID format is unique to Terraform and is composed of the Application's Object ID and the Password's Key ID in the format `{ObjectId}/{PasswordKeyId}`.
+-> **NOTE:** This ID format is unique to Terraform and is composed of the Application's Object ID, the string "password" and the Password's Key ID in the format `{ObjectId}/password/{PasswordKeyId}`.

--- a/website/docs/r/service_principal_certificate.html.markdown
+++ b/website/docs/r/service_principal_certificate.html.markdown
@@ -61,10 +61,10 @@ The following attributes are exported:
 
 ## Import
 
-Service Principal Certificates can be imported using the `object id`, e.g.
+Certificates can be imported using the `object id` of the Service Principal and the `key id` of the certificate, e.g.
 
 ```shell
-terraform import azuread_service_principal_certificate.test 00000000-0000-0000-0000-000000000000/11111111-1111-1111-1111-111111111111
+terraform import azuread_service_principal_certificate.test 00000000-0000-0000-0000-000000000000/certificate/11111111-1111-1111-1111-111111111111
 ```
 
--> **NOTE:** This ID format is unique to Terraform and is composed of the Service Principal's Object ID and the Service Principal Certificate's Key ID in the format `{ServicePrincipalObjectId}/{ServicePrincipalCertificateKeyId}`.
+-> **NOTE:** This ID format is unique to Terraform and is composed of the Service Principal's Object ID, the string "certificate" and the Certificate's Key ID in the format `{ServicePrincipalObjectId}/certificate/{CertificateKeyId}`.

--- a/website/docs/r/service_principal_password.html.markdown
+++ b/website/docs/r/service_principal_password.html.markdown
@@ -68,10 +68,10 @@ The following attributes are exported:
 
 ## Import
 
-Service Principal Passwords can be imported using the `object id`, e.g.
+PPasswords can be imported using the `object id` of a Service Principal and the `key id` of the password, e.g.
 
 ```shell
 terraform import azuread_service_principal_password.test 00000000-0000-0000-0000-000000000000/11111111-1111-1111-1111-111111111111
 ```
 
--> **NOTE:** This ID format is unique to Terraform and is composed of the Service Principal's Object ID and the Service Principal Password's Key ID in the format `{ServicePrincipalObjectId}/{ServicePrincipalPasswordKeyId}`.
+-> **NOTE:** This ID format is unique to Terraform and is composed of the Service Principal's Object ID, the string "password" and the Password's Key ID in the format `{ServicePrincipalObjectId}/password/{PasswordKeyId}`.


### PR DESCRIPTION
* New ID format inserts a string corresponding to resource type
* Should minimise risk of UUID collision
* FIx a bug in `azuread_application` where possibly nil optionalClaims was not handled