### PR TITLE
Stop requiring subscription_id and update configuration guides

### DIFF
--- a/azuread/data_client_config.go
+++ b/azuread/data_client_config.go
@@ -27,8 +27,9 @@ func dataClientConfig() *schema.Resource {
 			},
 
 			"subscription_id": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:       schema.TypeString,
+				Computed:   true,
+				Deprecated: fmt.Sprintf("The %q attribute will be removed in version 1.0 of the provider. If you are using this attribute, you should instead use the %q data source from the AzureRM provider", "subscription_id", "azurerm_client_config"),
 			},
 
 			"object_id": {
@@ -62,8 +63,12 @@ func dataSourceArmClientConfigRead(d *schema.ResourceData, meta interface{}) err
 	d.SetId(time.Now().UTC().String())
 	d.Set("client_id", client.clientID)
 	d.Set("object_id", client.objectID)
-	d.Set("subscription_id", client.subscriptionID)
 	d.Set("tenant_id", client.tenantID)
+
+	// TODO: remove in v1.0
+	if client.subscriptionID != client.tenantID {
+		d.Set("subscription_id", client.subscriptionID)
+	}
 
 	return nil
 }

--- a/azuread/data_client_config_test.go
+++ b/azuread/data_client_config_test.go
@@ -13,6 +13,27 @@ func TestAccClientConfigDataSource_basic(t *testing.T) {
 	dsn := "data.azuread_client_config.current"
 	clientId := os.Getenv("ARM_CLIENT_ID")
 	tenantId := os.Getenv("ARM_TENANT_ID")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckArmClientConfig_basic,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dsn, "client_id", clientId),
+					resource.TestCheckResourceAttr(dsn, "tenant_id", tenantId),
+					testAzureRMClientConfigGUIDAttr(dsn, "object_id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccClientConfigDataSource_basicDeprecated(t *testing.T) { // TODO: remove in v1.0
+	dsn := "data.azuread_client_config.current"
+	clientId := os.Getenv("ARM_CLIENT_ID")
+	tenantId := os.Getenv("ARM_TENANT_ID")
 	subscriptionId := os.Getenv("ARM_SUBSCRIPTION_ID")
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/azuread/provider_test.go
+++ b/azuread/provider_test.go
@@ -32,7 +32,6 @@ func TestProvider_impl(t *testing.T) {
 
 func testAccPreCheck(t *testing.T) {
 	variables := []string{
-		"ARM_SUBSCRIPTION_ID",
 		"ARM_CLIENT_ID",
 		"ARM_CLIENT_SECRET",
 		"ARM_TENANT_ID",

--- a/azuread/resource_application_certificate_test.go
+++ b/azuread/resource_application_certificate_test.go
@@ -103,7 +103,7 @@ func TestAccAzureADApplicationCertificate_basic(t *testing.T) {
 	resourceName := "azuread_application_certificate.test"
 	ri := tf.AccRandTimeInt()
 	keyType := "AsymmetricX509Cert"
-	endDate := time.Now().AddDate(0, 0, 360).UTC().Format(time.RFC3339)
+	endDate := time.Now().AddDate(0, 6, 0).UTC().Format(time.RFC3339)
 	value := testCertificateApplication
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -133,7 +133,7 @@ func TestAccAzureADApplicationCertificate_complete(t *testing.T) {
 	keyId := uuid.New().String()
 	keyType := "AsymmetricX509Cert"
 	startDate := time.Now().AddDate(0, 0, 7).UTC().Format(time.RFC3339)
-	endDate := time.Now().AddDate(0, 0, 360).UTC().Format(time.RFC3339)
+	endDate := time.Now().AddDate(0, 6, 0).UTC().Format(time.RFC3339)
 	value := testCertificateApplication
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -195,7 +195,7 @@ func TestAccAzureADApplicationCertificate_requiresImport(t *testing.T) {
 	resourceName := "azuread_application_certificate.test"
 	ri := tf.AccRandTimeInt()
 	keyType := "AsymmetricX509Cert"
-	endDate := time.Now().AddDate(0, 0, 360).UTC().Format(time.RFC3339)
+	endDate := time.Now().AddDate(0, 6, 0).UTC().Format(time.RFC3339)
 	value := testCertificateApplication
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -269,7 +269,7 @@ func testAccADApplicationCertificate_relativeEndDate(ri int, keyType, value stri
 
 resource "azuread_application_certificate" "test" {
   application_object_id = "${azuread_application.test.id}"
-  end_date_relative     = "8640h"
+  end_date_relative     = "4320h"
   type                  = "%s"
   value                 = <<EOT
 %s

--- a/azuread/resource_service_principal_certificate_test.go
+++ b/azuread/resource_service_principal_certificate_test.go
@@ -103,7 +103,7 @@ func TestAccAzureADServicePrincipalCertificate_basic(t *testing.T) {
 	resourceName := "azuread_service_principal_certificate.test"
 	ri := tf.AccRandTimeInt()
 	keyType := "AsymmetricX509Cert"
-	endDate := time.Now().AddDate(0, 0, 360).UTC().Format(time.RFC3339)
+	endDate := time.Now().AddDate(0, 6, 0).UTC().Format(time.RFC3339)
 	value := testCertificateServicePrincipal
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -133,7 +133,7 @@ func TestAccAzureADServicePrincipalCertificate_complete(t *testing.T) {
 	keyId := uuid.New().String()
 	keyType := "AsymmetricX509Cert"
 	startDate := time.Now().AddDate(0, 0, 7).UTC().Format(time.RFC3339)
-	endDate := time.Now().AddDate(0, 0, 360).UTC().Format(time.RFC3339)
+	endDate := time.Now().AddDate(0, 6, 0).UTC().Format(time.RFC3339)
 	value := testCertificateServicePrincipal
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -195,7 +195,7 @@ func TestAccAzureADServicePrincipalCertificate_requiresImport(t *testing.T) {
 	resourceName := "azuread_service_principal_certificate.test"
 	ri := tf.AccRandTimeInt()
 	keyType := "AsymmetricX509Cert"
-	endDate := time.Now().AddDate(0, 0, 360).UTC().Format(time.RFC3339)
+	endDate := time.Now().AddDate(0, 6, 0).UTC().Format(time.RFC3339)
 	value := testCertificateServicePrincipal
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -273,7 +273,7 @@ func testAccADServicePrincipalCertificate_relativeEndDate(ri int, keyType, value
 
 resource "azuread_service_principal_certificate" "test" {
   service_principal_id = "${azuread_service_principal.test.id}"
-  end_date_relative    = "8640h"
+  end_date_relative    = "4320h"
   type                 = "%s"
   value                = <<EOT
 %s

--- a/website/docs/guides/service_principal_client_secret.html.markdown
+++ b/website/docs/guides/service_principal_client_secret.html.markdown
@@ -16,156 +16,35 @@ Terraform supports a number of different methods for authenticating to Azure:
 * [Authenticating to Azure using a Service Principal and a Client Certificate](service_principal_client_certificate.html)
 * Authenticating to Azure using a Service Principal and a Client Secret (which is covered in this guide)
 
-Further steps must be taken to grant a Service Principal permission to manage objects in an Azure Active Directory:
- 
-[Granting a Service Principal permission to manage AAD](service_principal_configuration.html)
-
 ---
 
 We recommend using either a Service Principal or Managed Service Identity when running Terraform non-interactively (such as when running Terraform in a CI server) - and authenticating using the Azure CLI when running Terraform locally.
 
-Beyond authentication and managing Azure AAD resources further steps are required to make so a Service principal can make changes to Azure Active Directory objects such as users and groups. The [Granting a Service Principal permission to manage AAD](service_principal_configuration.html) guide contains the required steps.
+Once you have configured a Service Principal as described in this guide, you should follow the [Configuring a Service Principal for managing Azure Active Directory](service_principal_configuration.html) guide to grant the Service Principal necessary permissions to create and modify Azure Active Directory objects such as users and groups.
 
-## Creating a Service Principal
+## Setting up an Application and Service Principal
 
-A Service Principal is an application within Azure Active Directory whose authentication tokens can be used as the `client_id`, `client_secret`, and `tenant_id` fields needed by Terraform (`subscription_id` can be independently recovered from your Azure account details).
+A Service Principal is a security principal within Azure Active Directory which can be granted permissions to manage objects in Azure Active Directory. To authenticate with a Service Principal, you will need to create an Application object within Azure Active Directory, which you will use as a means of authentication, either [using a Client Secret](service_principal_client_secret.html) or a Client Certificate (which is documented in this guide). This can be done using the Azure Portal.
 
-It's possible to complete this task in either the [Azure CLI](#creating-a-service-principal-using-the-azure-cli) or in the [Azure Portal](#creating-a-service-principal-in-the-azure-portal) - in both we'll create a Service Principal which has `Contributor` rights to the subscription. [It's also possible to assign other rights](https://azure.microsoft.com/en-gb/documentation/articles/role-based-access-built-in-roles/) depending on your configuration.
+This guide will cover how to create an Application and linked Service Principal, and then how to generate a Client Secret for the Application so that it can be used for authentication.
 
-### Creating a Service Principal using the Azure CLI
+### Creating the Application and Service Principal
 
-~> **Note**: If you're using the **China**, **German** or **Government** Azure Clouds - you'll need to first configure the Azure CLI to work with that Cloud.  You can do this by running:
-
-```shell
-$ az cloud set --name AzureChinaCloud|AzureGermanCloud|AzureUSGovernment
-```
-
----
-
-Firstly, login to the Azure CLI using:
-
-```shell
-$ az login
-```
-
-Once logged in - it's possible to list the Subscriptions associated with the account via:
-
-```shell
-$ az account list
-```
-
-The output (similar to below) will display one or more Subscriptions - with the `id` field being the `subscription_id` field referenced above.
-
-```json
-[
-  {
-    "cloudName": "AzureCloud",
-    "id": "00000000-0000-0000-0000-000000000000",
-    "isDefault": true,
-    "name": "PAYG Subscription",
-    "state": "Enabled",
-    "tenantId": "00000000-0000-0000-0000-000000000000",
-    "user": {
-      "name": "user@example.com",
-      "type": "user"
-    }
-  }
-]
-```
-
-Should you have more than one Subscription, you can specify the Subscription to use via the following command:
-
-```shell
-$ az account set --subscription="SUBSCRIPTION_ID"
-```
-
-We can now create the Service Principal which will have permissions to manage resources in the specified Subscription using the following command:
-
-```shell
-$ az ad sp create-for-rbac --role="Contributor" --scopes="/subscriptions/SUBSCRIPTION_ID"
-```
-
-This command will output 5 values:
-
-```json
-{
-  "appId": "00000000-0000-0000-0000-000000000000",
-  "displayName": "azure-cli-2017-06-05-10-41-15",
-  "name": "http://azure-cli-2017-06-05-10-41-15",
-  "password": "0000-0000-0000-0000-000000000000",
-  "tenant": "00000000-0000-0000-0000-000000000000"
-}
-```
-
-These values map to the Terraform variables like so:
-
- - `appId` is the `client_id` defined above.
- - `password` is the `client_secret` defined above.
- - `tenant` is the `tenant_id` defined above.
-
----
-
-Finally, it's possible to test these values work as expected by first logging in:
-
-```shell
-$ az login --service-principal -u CLIENT_ID -p CLIENT_SECRET --tenant TENANT_ID
-```
-
-Once logged in as the Service Principal - we should be able to list the VM sizes by specifying an Azure region, for example here we use the `West US` region:
-
-```shell
-$ az vm list-sizes --location westus
-```
-
-~> **Note**: If you're using the **China**, **German** or **Government** Azure Clouds - you will need to switch `westus` out for another region. You can find which regions are available by running:
-
-```shell
-$ az account list-locations
-```
-
-Finally, since we're logged into the Azure CLI as a Service Principal we recommend logging out of the Azure CLI (but you can instead log in using your user account):
-
-```bash
-$ az logout
-```
-
-Information on how to configure the Provider block using the newly created Service Principal credentials can be found below.
-
----
-
-### Creating a Service Principal in the Azure Portal
-
-There are three tasks necessary to create a Service Principal using [the Azure Portal](https://portal.azure.com):
-
- 1. Create an Application in Azure Active Directory (which acts as a Service Principal)
- 2. Generating a Client Secret for the Azure Active Directory Application (which can be used for authentication)
- 3. Grant the Application access to manage resources in your Azure Subscription
-
-### 1. Creating an Application in Azure Active Directory
-
-Firstly navigate to [the **Azure Active Directory** overview](https://portal.azure.com/#blade/Microsoft_AAD_IAM/ActiveDirectoryMenuBlade/Overview) within the Azure Portal - [then select the **App Registration** blade](https://portal.azure.com/#blade/Microsoft_AAD_IAM/ActiveDirectoryMenuBlade/RegisteredApps/RegisteredApps/Overview) and click **Endpoints** at the top of the **App Registration** blade. A list of URIs will be displayed and you need to locate the URI for **OAUTH 2.0 AUTHORIZATION ENDPOINT** which contains a GUID. This GUID is your Tenant ID (the `tenant_id` field mentioned above).
-
-Next, navigate back to [the **App Registration** blade](https://portal.azure.com/#blade/Microsoft_AAD_IAM/ActiveDirectoryMenuBlade/RegisteredApps/RegisteredApps/Overview) - from here we'll create the Application in Azure Active Directory. To do this click **New application registration** at the top to add a new Application within Azure Active Directory. On this page, set the following values then press **Create**:
+We're going to create the Application in the Azure Portal - to do this navigate to the [**Azure Active Directory** overview][azure-portal-aad-overview] within the [Azure Portal][azure-portal] - then select the [**App Registrations** blade][azure-portal-applications-blade]. Click the **New registration** button at the top to add a new Application within Azure Active Directory. On this page, set the following values then press **Create**:
 
 - **Name** - this is a friendly identifier and can be anything (e.g. "Terraform")
-- **Application Type** - this should be set to "Web app / API"
-- **Sign-on URL** - this can be anything, providing it's a valid URI (e.g. https://terra.form)
+- **Supported Account Types** - this should be set to "Accounts in this organisational directory only (single tenant)"
+- **Redirect URI** - you should choose "Web" in for the URI type. the actual value can be left blank
 
-At this point the newly created Azure Active Directory application should be visible on-screen - if it's not, navigate to the [the **App Registration** blade](https://portal.azure.com/#blade/Microsoft_AAD_IAM/ActiveDirectoryMenuBlade/RegisteredApps/RegisteredApps/Overview) and select the Azure Active Directory application. At the top of this page, the "Application ID" GUID is the `client_id` you'll need.
+At this point the newly created Azure Active Directory application should be visible on-screen - if it's not, navigate to the [**App Registration** blade][azure-portal-applications-blade] and select the Azure Active Directory application.
 
-### 2. Generating a Client Secret for the Azure Active Directory Application
+At the top of this page, you'll need to take note of the "Application (client) ID" and the "Directory (tenant) ID", which you can use for the values of `client_id` and `tenant_id` respectively.
 
-Now that the Azure Active Directory Application exists we can create a Client Secret which can be used for authentication - to do this select **Settings** and then **Keys**. This screen displays the Passwords (Client Secrets) and Public Keys (Client Certificates) which are associated with this Azure Active Directory Application.
+### Generating a Client Secret for the Azure Active Directory Application
 
-On this screen we can generate a new Password by entering a Description and selecting an Expiry Date, and then pressing **Save**. Once the Password has been generated it will be displayed on screen - _the Password is only displayed once_ so **be sure to copy it now** (otherwise you will need to regenerate a new key). This newly generated Password is the `client_secret` you will need.
+Now that the Azure Active Directory Application exists we can create a Client Secret which can be used for authentication - to do this select **Certificates & secrets**. This screen displays the Certificates and Client Secrets (i.e. passwords) which are associated with this Azure Active Directory Application.
 
-### 3. Granting the Application access to manage resources in your Azure Subscription
-
-Once the Application exists in Azure Active Directory - we can grant it permissions to modify resources in the Subscription. To do this, [navigate to the **Subscriptions** blade within the Azure Portal](https://portal.azure.com/#blade/Microsoft_Azure_Billing/SubscriptionsBlade), then select the Subscription you wish to use, then click **Access Control (IAM)**, and finally **Add role assignment**.
-
-Firstly, specify a Role which grants the appropriate permissions needed for the Service Principal (for example, `Contributor` will grant Read/Write on all resources in the Subscription). There's more information about [the built in roles available here](https://azure.microsoft.com/en-gb/documentation/articles/role-based-access-built-in-roles/).
-
-Secondly, search for and select the name of the Application created in Azure Active Directory to assign it this role - then press **Save**.
+Click the "New client secret" button, then enter a short description, choose an expiry period and click "Add". Once the Client Secret has been generated it will be displayed on screen - _the secret is only displayed once_ so **be sure to copy it now** (otherwise you will need to regenerate a new one). This is the `client_secret` you will need.
 
 ---
 
@@ -178,22 +57,23 @@ When storing the credentials as Environment Variables, for example:
 ```bash
 $ export ARM_CLIENT_ID="00000000-0000-0000-0000-000000000000"
 $ export ARM_CLIENT_SECRET="00000000-0000-0000-0000-000000000000"
-$ export ARM_SUBSCRIPTION_ID="00000000-0000-0000-0000-000000000000"
-$ export ARM_TENANT_ID="00000000-0000-0000-0000-000000000000"
+$ export ARM_TENANT_ID="10000000-2000-3000-4000-500000000000"
 ```
 
-The following Provider block can be specified - where `1.20.0` is the version of the Azure Provider that you'd like to use:
+The following Provider block can be specified - where `0.10.0` is the version of the AzureAD Provider that you'd like to use:
 
 ```hcl
 provider "azuread" {
   # Whilst version is optional, we /strongly recommend/ using it to pin the version of the Provider being used
-  version = "=0.1.0"
+  version = "=0.10.0"
 }
 ```
 
 More information on [the fields supported in the Provider block can be found here](../index.html#argument-reference).
 
 At this point running either `terraform plan` or `terraform apply` should allow Terraform to run using the Service Principal to authenticate.
+
+Next you should follow the [Configuring a Service Principal for managing Azure Active Directory](service_principal_configuration.html) guide to grant the Service Principal necessary permissions to create and modify Azure Active Directory objects such as users and groups.
 
 ---
 
@@ -206,12 +86,11 @@ variable "client_secret" {}
 
 provider "azuread" {
   # Whilst version is optional, we /strongly recommend/ using it to pin the version of the Provider being used
-  version = "=0.1.0"
+  version = "=0.10.0"
 
-  subscription_id = "00000000-0000-0000-0000-000000000000"
-  client_id       = "00000000-0000-0000-0000-000000000000"
-  client_secret   = "${var.client_secret}"
-  tenant_id       = "00000000-0000-0000-0000-000000000000"
+  client_id     = "00000000-0000-0000-0000-000000000000"
+  client_secret = "${var.client_secret}"
+  tenant_id     = "10000000-2000-3000-4000-500000000000"
 }
 ```
 
@@ -219,4 +98,8 @@ More information on [the fields supported in the Provider block can be found her
 
 At this point running either `terraform plan` or `terraform apply` should allow Terraform to run using the Service Principal to authenticate.
 
-Next you may want to follow the [Granting a Service Principal permission to manage AAD](service_principal_configuration.html) guide to grant the Service Ability permission to create and modify Azure Active Directory objects such as users and groups.
+Next you should follow the [Configuring a Service Principal for managing Azure Active Directory](service_principal_configuration.html) guide to grant the Service Principal necessary permissions to create and modify Azure Active Directory objects such as users and groups.
+
+[azure-portal]: https://portal.azure.com/
+[azure-portal-aad-overview]: https://portal.azure.com/#blade/Microsoft_AAD_IAM/ActiveDirectoryMenuBlade/Overview
+[azure-portal-applications-blade]: https://portal.azure.com/#blade/Microsoft_AAD_IAM/ActiveDirectoryMenuBlade/RegisteredApps/RegisteredApps/Overview

--- a/website/docs/guides/service_principal_configuration.html.markdown
+++ b/website/docs/guides/service_principal_configuration.html.markdown
@@ -14,7 +14,7 @@ Terraform supports a number of different methods for authenticating to Azure:
 * [Authenticating to Azure using the Azure CLI](azure_cli.html)
 * [Authenticating to Azure using Managed Service Identity](managed_service_identity.html)
 * [Authenticating to Azure using a Service Principal and a Client Certificate](service_principal_client_certificate.html)
-* Authenticating to Azure using a Service Principal and a Client Secret (which is covered in this guide)
+* [Authenticating to Azure using a Service Principal and a Client Secret](service_principal_client_secret.html)
 
 Further steps must be taken to grant a Service Principal permission to manage objects in an Azure Active Directory:
 
@@ -26,77 +26,55 @@ We recommend using either a Service Principal or Managed Service Identity when r
 
 ## Creating a Service Principal
 
-A Service Principal is an application within Azure Active Directory whose authentication tokens can be used as the `client_id`, `client_secret`, and `tenant_id` fields needed by Terraform (`subscription_id` can be independently recovered from your Azure account details).
+A Service Principal represents an application within Azure Active Directory whose authentication tokens can be used as the `client_id`, `client_secret`, and `tenant_id` fields needed by Terraform.
 
 Depending on how the service principal authenticates to azure it can be created in a number of different ways: 
 * [Authenticating to Azure using a Service Principal and a Client Certificate](service_principal_client_certificate.html)
 * [Authenticating to Azure using a Service Principal and a Client Secret](service_principal_client_secret.html)
 
-## Granting administrator permissions
+## Azure Active Directory permissions
 
-~> **Note**: This requires the use of powershell cmdlets and is easiest to run in CloudShell.  
+Now that you have created and authenticated an Application / Service Principal pair, you will need to grant some permissions to administer Azure Active Directory. You can choose either of the following methods to achieve similar results.
+
+### Method 1: Directory Roles (recommended)
+
+With this method, you will assign directory roles to the Service Principal you created, to grant the desired permissions to administer objects in your Azure Active Directory tenant.
+
+Navigate to the [**Azure Active Directory** overview][azure-portal-aad-overview] within the [Azure Portal][azure-portal]. Go to the [**Roles and Administrators** blade][azure-portal-aad-roles-blade].
+
+Locate the role you wish to assign and click on it. Consult the [documentation for administrator role permissions][admin-roles-docs] from Microsoft for more information about the available roles and the permissions they grant.
+
+Click "Add assignments" and type the name of your Service Principal in the search box to locate it. If you know the Object ID of the Service Principal, verify that it is the same. Select it and click the "Add" button to assign the role.
+
+The choice of which directory roles to assign will be specific to your organisations Commonly used roles include:
+
+- `Global Administrator` - Effective superuser permissions to administer any object in your AAD tenant. Sometimes called `Company Administrator`.
+- `Global Reader` - Commonly used in conjunction with other roles to allow reading, but not writing, of directory data.
+- `Application Administrator` - Create and manage applications, service principals (enterprise applications) and application proxy.
+- `Groups Administrator` - Create and manage groups.
+- `User Administrator` - Create and manage users _and_ groups.
+
+### Method 2: API access with admin consent
+
+This method involves granting API scopes to your Application, and then granting consent for your Application to access the APIs in its own capacity (i.e. not on behalf of a user).
+
+Navigate to the [**Azure Active Directory** overview][azure-portal-aad-overview] within the [Azure Portal][azure-portal] and select the [**App Registrations** blade][azure-portal-applications-blade]. Locate your registered Application and click on its display name to manage it.
+
+Go to the API Permissions blade for the Application and click the "Add a permission" button. In the pane that opens, select "Azure Active Directory Graph" (under the Supported Legacy APIs subheading). Do not select "Microsoft Graph", as the provider does not currently make use of this API.
+
+Choose "Application Permissions" for the permission type, and check the permissions you would like to assign. The permissions you need will depend on which directory objects you are seeking to manage with Terraform. We suggest the following permissions:
+
+- `Application.ReadWrite.All`
+- `Directory.ReadWrite.All`
+
+Note that these permissions do not cover all use cases. Notable actions you cannot perform with permissions granted in this way include deleting groups and deleting users.
+
+Once you have assigned the permissions, you will need to grant admin consent. This requires that you are signed in to the Portal as a Global Administrator. Click the "Grant admin consent" button and confirm the action.
+
+The Application now has permission to administer your Azure Active Directory tenant.
 
 
-Firstly, connect to the directory using:
-
-```shell
-Connect-AzureAD -TenantID "00000000-0000-0000-0000-000000000000"
-```
-
-Next we want to get the correct role to assign, in this case `User Account Administrator`:
-
-```shell
-$role = Get-AzureADDirectoryRole | Where-Object {$_.displayName -eq 'User Account Administrator'}
-Write-Host $role
-```
-
-Since this is a built-in Role, if this doesn't exist (returns `null` above) then we need to instantiate it from the Role Template:
-
-```shell
-if ($role -eq $null) {
-    # Instantiate an instance of the role template
-    $roleTemplate = Get-AzureADDirectoryRoleTemplate | Where-Object {$_.displayName -eq 'User Account Administrator'}
-    Enable-AzureADDirectoryRole -RoleTemplateId $roleTemplate.ObjectId
-
-    # Fetch User Account Administrator role instance again
-    $role = Get-AzureADDirectoryRole | Where-Object {$_.displayName -eq 'User Account Administrator'}
-}
-```
-
-Next we need the Client ID (sometimes referred to as the Application ID) of the Service Principal. We can look this up by it's display name:
-
-```shell
-$sp = Get-AzureADServicePrincipal -All $true | Where-Object {$_.displayName -eq 'Service Principal Name'}
-$sp.ObjectId
-```
-
-Now that we have all the required information we can add the service principal to the role:
-
-```shell
-Add-AzureADDirectoryRoleMember -ObjectId $role.ObjectId -RefObjectId $sp.ObjectId
-
-```
-
-Finally we can repeat this for the `Company Administrator` role:
-
-```shell
-$role = Get-AzureADDirectoryRole | Where-Object {$_.displayName -eq 'Company Administrator'}
-$role
-
-if ($role -eq $null) {
-    # Instantiate an instance of the role template
-    $roleTemplate = Get-AzureADDirectoryRoleTemplate | Where-Object {$_.displayName -eq 'Company Administrator'}
-    Enable-AzureADDirectoryRole -RoleTemplateId $roleTemplate.ObjectId
-
-    # Fetch User Account Administrator role instance again
-    $role = Get-AzureADDirectoryRole | Where-Object {$_.displayName -eq 'Company Administrator'}
-}
-
-$sp = Get-AzureADServicePrincipal | Where-Object {$_.displayName -eq 'Service Principal Name'}
-$sp.ObjectId
-
-Add-AzureADDirectoryRoleMember -ObjectId $role.ObjectId -RefObjectId $sp.ObjectId
-
-```
-
-At this point you should now be able to manage Users, Groups and other Azure Active Directory resources using Terraform.
+[admin-roles-docs]: https://docs.microsoft.com/en-us/azure/active-directory/users-groups-roles/directory-assign-admin-roles
+[azure-portal]: https://portal.azure.com/
+[azure-portal-aad-overview]: https://portal.azure.com/#blade/Microsoft_AAD_IAM/ActiveDirectoryMenuBlade/Overview
+[azure-portal-aad-roles-blade]: https://portal.azure.com/#blade/Microsoft_AAD_IAM/ActiveDirectoryMenuBlade/RolesAndAdministrators


### PR DESCRIPTION
Stop requiring a subscription ID to be configured (though still allow it for compatibility)
  - See 44829f2621da31096fe4b06d3ca810631dc078b2

Configuration guide updates
  - Walkthroughs reflect current portal experience
  - Amend guidance on AAD permissions
    - Document some common AAD roles and API scopes
    - Note on subscription ID
  - Remove references to configuring subscriptions

Also fix up certificate related tests by shortening validity period to 6 months

**DEPRECATION WARNING**

The `subscription_id` attribute will be removed from the `azuread_client_config` data source in v1.0. The subscription ID here is only an echo of the subscription ID supplied by the user and there is no possible way to use it currently elsewhere in the provider. Configurations can switch over to the `azurerm_client_config` data source.

Closes: #232