### PR TITLE
Syntax updates for Terraform 0.12, support application_id argument on data.azuread_application

### DIFF
--- a/azuread/data_application_test.go
+++ b/azuread/data_application_test.go
@@ -78,6 +78,36 @@ func TestAccAzureADApplicationDataSource_byObjectIdComplete(t *testing.T) {
 	})
 }
 
+func TestAccAzureADApplicationDataSource_byApplicationId(t *testing.T) {
+	dataSourceName := "data.azuread_application.test"
+	ri := tf.AccRandTimeInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckADApplicationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccADApplication_basic(ri),
+			},
+			{
+				Config: testAccAzureADApplicationDataSource_applicationId(ri),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckADApplicationExists(dataSourceName),
+					resource.TestCheckResourceAttr(dataSourceName, "name", fmt.Sprintf("acctest-APP-%d", ri)),
+					resource.TestCheckResourceAttr(dataSourceName, "homepage", fmt.Sprintf("https://acctest-APP-%d", ri)),
+					resource.TestCheckResourceAttr(dataSourceName, "identifier_uris.#", "0"),
+					resource.TestCheckResourceAttr(dataSourceName, "reply_urls.#", "0"),
+					resource.TestCheckResourceAttr(dataSourceName, "optional_claims.#", "0"),
+					resource.TestCheckResourceAttr(dataSourceName, "required_resource_access.#", "0"),
+					resource.TestCheckResourceAttr(dataSourceName, "oauth2_allow_implicit_flow", "false"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "application_id"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAzureADApplicationDataSource_byName(t *testing.T) {
 	dataSourceName := "data.azuread_application.test"
 	ri := tf.AccRandTimeInt()
@@ -114,7 +144,7 @@ func testAccAzureADApplicationDataSource_objectId(ri int) string {
 %s
 
 data "azuread_application" "test" {
-  object_id = "${azuread_application.test.object_id}"
+  object_id = azuread_application.test.object_id
 }
 `, template)
 }
@@ -125,7 +155,18 @@ func testAccAzureADApplicationDataSource_objectIdComplete(ri int, pw string) str
 %s
 
 data "azuread_application" "test" {
-  object_id = "${azuread_application.test.object_id}"
+  object_id = azuread_application.test.object_id
+}
+`, template)
+}
+
+func testAccAzureADApplicationDataSource_applicationId(ri int) string {
+	template := testAccADApplication_basic(ri)
+	return fmt.Sprintf(`
+%s
+
+data "azuread_application" "test" {
+  application_id = azuread_application.test.application_id
 }
 `, template)
 }
@@ -136,7 +177,7 @@ func testAccAzureADApplicationDataSource_name(ri int) string {
 %s
 
 data "azuread_application" "test" {
-  name = "${azuread_application.test.name}"
+  name = azuread_application.test.name
 }
 `, template)
 }

--- a/azuread/data_group_test.go
+++ b/azuread/data_group_test.go
@@ -99,7 +99,7 @@ func testAccDataSourceAzureADGroup_name(id int) string {
 %s
 
 data "azuread_group" "test" {
-  name = "${azuread_group.test.name}"
+  name = azuread_group.test.name
 }
 `, testAccAzureADGroup_basic(id))
 }
@@ -109,7 +109,7 @@ func testAccDataSourceAzureADGroup_objectId(id int) string {
 %s
 
 data "azuread_group" "test" {
-  object_id = "${azuread_group.test.object_id}"
+  object_id = azuread_group.test.object_id
 }
 `, testAccAzureADGroup_basic(id))
 }
@@ -119,7 +119,7 @@ func testAccDataSourceAzureADGroup_members(id int, password string) string {
 %s
 
 data "azuread_group" "test" {
-  object_id = "${azuread_group.test.object_id}"
+  object_id = azuread_group.test.object_id
 }
 `, testAccAzureADGroupWithThreeMembers(id, password))
 }
@@ -129,7 +129,7 @@ func testAccDataSourceAzureADGroup_owners(id int, password string) string {
 %s
 
 data "azuread_group" "test" {
-  object_id = "${azuread_group.test.object_id}"
+  object_id = azuread_group.test.object_id
 }
 `, testAccAzureADGroupWithThreeOwners(id, password))
 }

--- a/azuread/data_groups_test.go
+++ b/azuread/data_groups_test.go
@@ -84,7 +84,7 @@ func testAccAzureADGroupsDataSource_byDisplayNames(id int) string {
 %s
 
 data "azuread_groups" "test" {
-  names = ["${azuread_group.testA.name}", "${azuread_group.testB.name}"]
+  names = [azuread_group.testA.name, azuread_group.testB.name]
 }
 `, testAccAzureADGroup_multiple(id))
 }
@@ -94,7 +94,7 @@ func testAccAzureADGroupsDataSource_byObjectIds(id int) string {
 %s
 
 data "azuread_groups" "test" {
-  object_ids = ["${azuread_group.testA.object_id}", "${azuread_group.testB.object_id}"]
+  object_ids = [azuread_group.testA.object_id, azuread_group.testB.object_id]
 }
 `, testAccAzureADGroup_multiple(id))
 }

--- a/azuread/data_service_principal_test.go
+++ b/azuread/data_service_principal_test.go
@@ -83,7 +83,7 @@ func testAccAzureADServicePrincipalDataSource_byApplicationId(id string) string 
 %s
 
 data "azuread_service_principal" "test" {
-  application_id = "${azuread_service_principal.test.application_id}"
+  application_id = azuread_service_principal.test.application_id
 }
 `, template)
 }
@@ -94,7 +94,7 @@ func testAccAzureADServicePrincipalDataSource_byDisplayName(id string) string {
 %s
 
 data "azuread_service_principal" "test" {
-  display_name = "${azuread_service_principal.test.display_name}"
+  display_name = azuread_service_principal.test.display_name
 }
 `, template)
 }
@@ -105,7 +105,7 @@ func testAccAzureADServicePrincipalDataSource_byObjectId(id string) string {
 %s
 
 data "azuread_service_principal" "test" {
-  object_id = "${azuread_service_principal.test.object_id}"
+  object_id = azuread_service_principal.test.object_id
 }
 `, template)
 }

--- a/azuread/data_user_test.go
+++ b/azuread/data_user_test.go
@@ -81,7 +81,7 @@ func testAccAzureADUserDataSource_byUserPrincipalName(id int, password string) s
 %s
 
 data "azuread_user" "test" {
-  user_principal_name = "${azuread_user.test.user_principal_name}"
+  user_principal_name = azuread_user.test.user_principal_name
 }
 `, testAccADUser_basic(id, password))
 }
@@ -91,7 +91,7 @@ func testAccAzureADUserDataSource_byObjectId(id int, password string) string {
 %s
 
 data "azuread_user" "test" {
-  object_id = "${azuread_user.test.object_id}"
+  object_id = azuread_user.test.object_id
 }
 `, testAccADUser_basic(id, password))
 }
@@ -101,7 +101,7 @@ func testAccAzureADUserDataSource_byMailNickname(id int, password string) string
 %s
 
 data "azuread_user" "test" {
-  mail_nickname = "${azuread_user.test.mail_nickname}"
+  mail_nickname = azuread_user.test.mail_nickname
 }
 `, testAccADUser_basic(id, password))
 }

--- a/azuread/data_users_test.go
+++ b/azuread/data_users_test.go
@@ -95,7 +95,7 @@ func testAccAzureADUsersDataSource_byUserPrincipalNames(id int, password string)
 %s
 
 data "azuread_users" "test" {
-  user_principal_names = ["${azuread_user.testA.user_principal_name}", "${azuread_user.testB.user_principal_name}"]
+  user_principal_names = [azuread_user.testA.user_principal_name, azuread_user.testB.user_principal_name]
 }
 `, testAccADUser_threeUsersABC(id, password))
 }
@@ -105,7 +105,7 @@ func testAccAzureADUsersDataSource_byObjectIds(id int, password string) string {
 %s
 
 data "azuread_users" "test" {
-  object_ids = ["${azuread_user.testA.object_id}", "${azuread_user.testB.object_id}"]
+  object_ids = [azuread_user.testA.object_id, azuread_user.testB.object_id]
 }
 `, testAccADUser_threeUsersABC(id, password))
 }
@@ -115,7 +115,7 @@ func testAccAzureADUsersDataSource_byMailNicknames(id int, password string) stri
 %s
 
 data "azuread_users" "test" {
-  mail_nicknames = ["${azuread_user.testA.mail_nickname}", "${azuread_user.testB.mail_nickname}"]
+  mail_nicknames = [azuread_user.testA.mail_nickname, azuread_user.testB.mail_nickname]
 }
 `, testAccADUser_threeUsersABC(id, password))
 }

--- a/azuread/resource_application_certificate_test.go
+++ b/azuread/resource_application_certificate_test.go
@@ -236,7 +236,7 @@ func testAccADObjectCertificateApplication_basic(ri int, keyType, endDate, value
 %s
 
 resource "azuread_application_certificate" "test" {
-  application_object_id = "${azuread_application.test.id}"
+  application_object_id = azuread_application.test.id
   type                  = "%s"
   end_date              = "%s"
   value                 = <<EOT
@@ -251,7 +251,7 @@ func testAccADApplicationCertificate_complete(ri int, keyId, keyType, startDate,
 %s
 
 resource "azuread_application_certificate" "test" {
-  application_object_id = "${azuread_application.test.id}"
+  application_object_id = azuread_application.test.id
   key_id                = "%s"
   type                  = "%s"
   start_date            = "%s"
@@ -268,7 +268,7 @@ func testAccADApplicationCertificate_relativeEndDate(ri int, keyType, value stri
 %s
 
 resource "azuread_application_certificate" "test" {
-  application_object_id = "${azuread_application.test.id}"
+  application_object_id = azuread_application.test.id
   end_date_relative     = "4320h"
   type                  = "%s"
   value                 = <<EOT
@@ -284,11 +284,11 @@ func testAccADApplicationCertificate_requiresImport(ri int, keyType, endDate, va
 %s
 
 resource "azuread_application_certificate" "import" {
-  application_object_id = "${azuread_application_certificate.test.application_object_id}"
-  key_id                = "${azuread_application_certificate.test.key_id}"
-  type                  = "${azuread_application_certificate.test.type}"
-  end_date              = "${azuread_application_certificate.test.end_date}"
-  value                 = "${azuread_application_certificate.test.value}"
+  application_object_id = azuread_application_certificate.test.application_object_id
+  key_id                = azuread_application_certificate.test.key_id
+  type                  = azuread_application_certificate.test.type
+  end_date              = azuread_application_certificate.test.end_date
+  value                 = azuread_application_certificate.test.value
 }
 `, template)
 }

--- a/azuread/resource_application_password_test.go
+++ b/azuread/resource_application_password_test.go
@@ -268,7 +268,7 @@ func testAccADObjectPasswordApplication_basic(applicationId, value string) strin
 %s
 
 resource "azuread_application_password" "test" {
-  application_object_id = "${azuread_application.test.id}"
+  application_object_id = azuread_application.test.id
   value                 = "%s"
   end_date              = "2099-01-01T01:02:03Z"
 }
@@ -280,7 +280,7 @@ func testAccADObjectPasswordApplication_basicOld(applicationId, value string) st
 %s
 
 resource "azuread_application_password" "test" {
-  application_id = "${azuread_application.test.id}"
+  application_id = azuread_application.test.id
   value          = "%s"
   end_date       = "2099-01-01T01:02:03Z"
 }
@@ -293,10 +293,10 @@ func testAccADApplicationPassword_requiresImport(applicationId, value string) st
 %s
 
 resource "azuread_application_password" "import" {
-  application_object_id = "${azuread_application_password.test.application_object_id}"
-  key_id                = "${azuread_application_password.test.key_id}"
-  value                 = "${azuread_application_password.test.value}"
-  end_date              = "${azuread_application_password.test.end_date}"
+  application_object_id = azuread_application_password.test.application_object_id
+  key_id                = azuread_application_password.test.key_id
+  value                 = azuread_application_password.test.value
+  end_date              = azuread_application_password.test.end_date
 }
 `, template)
 }
@@ -306,7 +306,7 @@ func testAccADApplicationPassword_customKeyId(applicationId, keyId, value string
 %s
 
 resource "azuread_application_password" "test" {
-  application_object_id = "${azuread_application.test.id}"
+  application_object_id = azuread_application.test.id
   key_id                = "%s"
   value                 = "%s"
   end_date              = "2099-01-01T01:02:03Z"
@@ -319,7 +319,7 @@ func testAccADApplicationPassword_description(applicationId, value string) strin
 %s
 
 resource "azuread_application_password" "test" {
-  application_object_id = "${azuread_application.test.id}"
+  application_object_id = azuread_application.test.id
   description           = "terraform"
   value                 = "%s"
   end_date              = "2099-01-01T01:02:03Z"
@@ -332,7 +332,7 @@ func testAccADApplicationPassword_relativeEndDate(applicationId, value string) s
 %s
 
 resource "azuread_application_password" "test" {
-  application_object_id = "${azuread_application.test.id}"
+  application_object_id = azuread_application.test.id
   value                 = "%s"
   end_date_relative     = "8760h"
 }

--- a/azuread/resource_group_member_test.go
+++ b/azuread/resource_group_member_test.go
@@ -200,8 +200,8 @@ resource "azuread_group" "test" {
 }
 
 resource "azuread_group_member" "testA" {
-  group_object_id  = "${azuread_group.test.object_id}"
-  member_object_id = "${azuread_user.testA.object_id}"
+  group_object_id  = azuread_group.test.object_id
+  member_object_id = azuread_user.testA.object_id
 }
 
 `, testAccADUser_threeUsersABC(id, password), id)
@@ -216,13 +216,13 @@ resource "azuread_group" "test" {
 }
 
 resource "azuread_group_member" "testA" {
-  group_object_id  = "${azuread_group.test.object_id}"
-  member_object_id = "${azuread_user.testA.object_id}"
+  group_object_id  = azuread_group.test.object_id
+  member_object_id = azuread_user.testA.object_id
 }
 
 resource "azuread_group_member" "testB" {
-  group_object_id  = "${azuread_group.test.object_id}"
-  member_object_id = "${azuread_user.testB.object_id}"
+  group_object_id  = azuread_group.test.object_id
+  member_object_id = azuread_user.testB.object_id
 }
 
 `, testAccADUser_threeUsersABC(id, password), id)
@@ -240,8 +240,8 @@ resource "azuread_group" "member" {
 }
 
 resource "azuread_group_member" "test" {
-  group_object_id  = "${azuread_group.test.object_id}"
-  member_object_id = "${azuread_group.member.object_id}"
+  group_object_id  = azuread_group.test.object_id
+  member_object_id = azuread_group.member.object_id
 }
 
 `, id)
@@ -255,7 +255,7 @@ resource "azuread_application" "test" {
 }
 
 resource "azuread_service_principal" "test" {
-  application_id = "${azuread_application.test.application_id}"
+  application_id = azuread_application.test.application_id
 }
 
 resource "azuread_group" "test" {
@@ -263,8 +263,8 @@ resource "azuread_group" "test" {
 }
 
 resource "azuread_group_member" "test" {
-  group_object_id  = "${azuread_group.test.object_id}"
-  member_object_id = "${azuread_service_principal.test.object_id}"
+  group_object_id  = azuread_group.test.object_id
+  member_object_id = azuread_service_principal.test.object_id
 }
 
 `, id)

--- a/azuread/resource_service_principal_certificate_test.go
+++ b/azuread/resource_service_principal_certificate_test.go
@@ -230,7 +230,7 @@ resource "azuread_application" "test" {
 }
 
 resource "azuread_service_principal" "test" {
-  application_id = "${azuread_application.test.application_id}"
+  application_id = azuread_application.test.application_id
 }
 `, ri)
 }
@@ -240,7 +240,7 @@ func testAccADObjectCertificateServicePrincipal_basic(ri int, keyType, endDate, 
 %s
 
 resource "azuread_service_principal_certificate" "test" {
-  service_principal_id = "${azuread_service_principal.test.id}"
+  service_principal_id = azuread_service_principal.test.id
   type                 = "%s"
   end_date             = "%s"
   value                = <<EOT
@@ -255,7 +255,7 @@ func testAccADServicePrincipalCertificate_complete(ri int, keyId, keyType, start
 %s
 
 resource "azuread_service_principal_certificate" "test" {
-  service_principal_id = "${azuread_service_principal.test.id}"
+  service_principal_id = azuread_service_principal.test.id
   key_id               = "%s"
   type                 = "%s"
   start_date           = "%s"
@@ -272,7 +272,7 @@ func testAccADServicePrincipalCertificate_relativeEndDate(ri int, keyType, value
 %s
 
 resource "azuread_service_principal_certificate" "test" {
-  service_principal_id = "${azuread_service_principal.test.id}"
+  service_principal_id = azuread_service_principal.test.id
   end_date_relative    = "4320h"
   type                 = "%s"
   value                = <<EOT
@@ -288,11 +288,11 @@ func testAccADServicePrincipalCertificate_requiresImport(ri int, keyType, endDat
 %s
 
 resource "azuread_service_principal_certificate" "import" {
-  service_principal_id = "${azuread_service_principal_certificate.test.service_principal_id}"
-  key_id               = "${azuread_service_principal_certificate.test.key_id}"
-  type                 = "${azuread_service_principal_certificate.test.type}"
-  end_date             = "${azuread_service_principal_certificate.test.end_date}"
-  value                = "${azuread_service_principal_certificate.test.value}"
+  service_principal_id = azuread_service_principal_certificate.test.service_principal_id
+  key_id               = azuread_service_principal_certificate.test.key_id
+  type                 = azuread_service_principal_certificate.test.type
+  end_date             = azuread_service_principal_certificate.test.end_date
+  value                = azuread_service_principal_certificate.test.value
 }
 `, template)
 }

--- a/azuread/resource_service_principal_password_test.go
+++ b/azuread/resource_service_principal_password_test.go
@@ -235,7 +235,7 @@ resource "azuread_application" "test" {
 }
 
 resource "azuread_service_principal" "test" {
-  application_id = "${azuread_application.test.application_id}"
+  application_id = azuread_application.test.application_id
 }
 `, applicationId)
 }
@@ -245,7 +245,7 @@ func testAccADServicePrincipalPassword_basic(applicationId, value string) string
 %s
 
 resource "azuread_service_principal_password" "test" {
-  service_principal_id = "${azuread_service_principal.test.id}"
+  service_principal_id = azuread_service_principal.test.id
   value                = "%s"
   end_date             = "2099-01-01T01:02:03Z"
 }
@@ -258,10 +258,10 @@ func testAccADServicePrincipalPassword_requiresImport(applicationId, value strin
 %s
 
 resource "azuread_service_principal_password" "import" {
-  key_id               = "${azuread_service_principal_password.test.key_id}"
-  service_principal_id = "${azuread_service_principal_password.test.service_principal_id}"
-  value                = "${azuread_service_principal_password.test.value}"
-  end_date             = "${azuread_service_principal_password.test.end_date}"
+  key_id               = azuread_service_principal_password.test.key_id
+  service_principal_id = azuread_service_principal_password.test.service_principal_id
+  value                = azuread_service_principal_password.test.value
+  end_date             = azuread_service_principal_password.test.end_date
 }
 `, template)
 }
@@ -271,7 +271,7 @@ func testAccADServicePrincipalPassword_customKeyId(applicationId, keyId, value s
 %s
 
 resource "azuread_service_principal_password" "test" {
-  service_principal_id = "${azuread_service_principal.test.id}"
+  service_principal_id = azuread_service_principal.test.id
   key_id               = "%s"
   value                = "%s"
   end_date             = "2099-01-01T01:02:03Z"
@@ -284,7 +284,7 @@ func testAccADServicePrincipalPassword_description(applicationId, value string) 
 %s
 
 resource "azuread_service_principal_password" "test" {
-  service_principal_id = "${azuread_service_principal.test.id}"
+  service_principal_id = azuread_service_principal.test.id
   description          = "terraform"
   value                = "%s"
   end_date             = "2099-01-01T01:02:03Z"
@@ -297,7 +297,7 @@ func testAccADServicePrincipalPassword_relativeEndDate(applicationId, value stri
 %s
 
 resource "azuread_service_principal_password" "test" {
-  service_principal_id = "${azuread_service_principal.test.id}"
+  service_principal_id = azuread_service_principal.test.id
   value                = "%s"
   end_date_relative    = "8760h"
 }

--- a/azuread/resource_service_principal_test.go
+++ b/azuread/resource_service_principal_test.go
@@ -167,7 +167,7 @@ resource "azuread_application" "test" {
 }
 
 resource "azuread_service_principal" "test" {
-  application_id = "${azuread_application.test.application_id}"
+  application_id = azuread_application.test.application_id
 }
 `, id)
 }
@@ -179,7 +179,7 @@ resource "azuread_application" "test" {
 }
 
 resource "azuread_service_principal" "test" {
-  application_id               = "${azuread_application.test.application_id}"
+  application_id               = azuread_application.test.application_id
   app_role_assignment_required = true
 
   tags = ["test", "multiple", "CapitalS"]

--- a/website/docs/d/application.html.markdown
+++ b/website/docs/d/application.html.markdown
@@ -20,7 +20,7 @@ data "azuread_application" "example" {
 }
 
 output "azure_ad_object_id" {
-  value = "${data.azuread_application.example.id}"
+  value = data.azuread_application.example.id
 }
 ```
 
@@ -28,9 +28,11 @@ output "azure_ad_object_id" {
 
 * `object_id` - (Optional) Specifies the Object ID of the Application within Azure Active Directory.
 
+* `application_id` - (Optional) Specifies the Application ID of the Azure Active Directory Application.
+
 * `name` - (Optional) Specifies the name of the Application within Azure Active Directory.
 
--> **NOTE:** Either an `object_id` or `name` must be specified.
+-> **NOTE:** One of `object_id`, `application_id` or `name` must be specified.
 
 ## Attributes Reference
 

--- a/website/docs/d/domains.html.markdown
+++ b/website/docs/d/domains.html.markdown
@@ -18,7 +18,7 @@ Use this data source to access information about an existing Domains within Azur
 data "azuread_domains" "aad_domains" {}
 
 output "domains" {
-  value = "${data.azuread_domains.aad_domains.domains}"
+  value = data.azuread_domains.aad_domains.domains
 }
 ```
 

--- a/website/docs/r/application_certificate.html.markdown
+++ b/website/docs/r/application_certificate.html.markdown
@@ -21,9 +21,9 @@ resource "azuread_application" "example" {
 }
 
 resource "azuread_application_certificate" "example" {
-  application_object_id = "${azuread_application.example.id}"
+  application_object_id = azuread_application.example.id
   type                  = "AsymmetricX509Cert"
-  value                 = "${file("cert.pem")}"
+  value                 = file("cert.pem")
   end_date              = "2021-05-01T01:02:03Z"
 }
 ```

--- a/website/docs/r/application_password.html.markdown
+++ b/website/docs/r/application_password.html.markdown
@@ -17,16 +17,11 @@ Manages a Password associated with an Application within Azure Active Directory.
 
 ```hcl
 resource "azuread_application" "example" {
-  name                       = "example"
-  homepage                   = "http://homepage"
-  identifier_uris            = ["http://uri"]
-  reply_urls                 = ["http://replyurl"]
-  available_to_other_tenants = false
-  oauth2_allow_implicit_flow = true
+  name = "example"
 }
 
 resource "azuread_application_password" "example" {
-  application_object_id = "${azuread_application.example.id}"
+  application_object_id = azuread_application.example.id
   description           = "My managed password"
   value                 = "VT=uSgbTanZhyz@%nL9Hpd+Tfay_MRV#"
   end_date              = "2099-01-01T01:02:03Z"

--- a/website/docs/r/group.markdown
+++ b/website/docs/r/group.markdown
@@ -29,12 +29,15 @@ resource "azuread_group" "example" {
 resource "azuread_user" "example" {
   display_name          = "J Doe"
   password              = "notSecure123"
-  user_principal_name   = "j.doe@terraform.onmicrosoft.com"
+  user_principal_name   = "jdoe@hashicorp.com"
 }
 
 resource "azuread_group" "example" {
   name    = "MyGroup"
-  members = [ "${azuread_user.example.object_id}" /*, more users */ ]
+  members = [
+    azuread_user.example.object_id,
+    /* more users */
+  ]
 }
 ```
 

--- a/website/docs/r/group_member.markdown
+++ b/website/docs/r/group_member.markdown
@@ -26,8 +26,8 @@ resource "azuread_group" "example" {
 }
 
 resource "azuread_group_member" "example" {
-  group_object_id   = "${azuread_group.example.id}"
-  member_object_id  = "${data.azuread_user.example.id}"
+  group_object_id   = azuread_group.example.id
+  member_object_id  = data.azuread_user.example.id
 }
 ```
 

--- a/website/docs/r/service_principal.html.markdown
+++ b/website/docs/r/service_principal.html.markdown
@@ -25,7 +25,7 @@ resource "azuread_application" "example" {
 }
 
 resource "azuread_service_principal" "example" {
-  application_id               = "${azuread_application.example.application_id}"
+  application_id               = azuread_application.example.application_id
   app_role_assignment_required = false
 
   tags = ["example", "tags", "here"]

--- a/website/docs/r/service_principal_certificate.html.markdown
+++ b/website/docs/r/service_principal_certificate.html.markdown
@@ -21,13 +21,13 @@ resource "azuread_application" "example" {
 }
 
 resource "azuread_service_principal" "example" {
-  application_id = "${azuread_application.example.application_id}"
+  application_id = azuread_application.example.application_id
 }
 
 resource "azuread_service_principal_certificate" "example" {
-  service_principal_id = "${azuread_service_principal.example.id}"
+  service_principal_id = azuread_service_principal.example.id
   type                 = "AsymmetricX509Cert"
-  value                = "${file("cert.pem")}"
+  value                = file("cert.pem")
   end_date             = "2021-05-01T01:02:03Z"
 }
 ```

--- a/website/docs/r/service_principal_password.html.markdown
+++ b/website/docs/r/service_principal_password.html.markdown
@@ -17,20 +17,15 @@ Manages a Password associated with a Service Principal within Azure Active Direc
 
 ```hcl
 resource "azuread_application" "example" {
-  name                       = "example"
-  homepage                   = "http://homepage"
-  identifier_uris            = ["http://uri"]
-  reply_urls                 = ["http://replyurl"]
-  available_to_other_tenants = false
-  oauth2_allow_implicit_flow = true
+  name = "example"
 }
 
 resource "azuread_service_principal" "example" {
-  application_id = "${azuread_application.example.application_id}"
+  application_id = azuread_application.example.application_id
 }
 
 resource "azuread_service_principal_password" "example" {
-  service_principal_id = "${azuread_service_principal.example.id}"
+  service_principal_id = azuread_service_principal.example.id
   description          = "My managed password"
   value                = "VT=uSgbTanZhyz@%nL9Hpd+Tfay_MRV#"
   end_date             = "2099-01-01T01:02:03Z"

--- a/website/docs/r/user.html.markdown
+++ b/website/docs/r/user.html.markdown
@@ -17,7 +17,7 @@ Manages a User within Azure Active Directory.
 
 ```hcl
 resource "azuread_user" "example" {
-  user_principal_name = "jdo@hashicorp.com"
+  user_principal_name = "jdoe@hashicorp.com"
   display_name        = "J. Doe"
   mail_nickname       = "jdoe"
   password            = "SecretP@sswd99!"


### PR DESCRIPTION
* Update documentation examples and acceptance test configs to use Terraform 0.12 style expressions
* Support the `application_id` argument for `data.azuread_application` for locating applications