### PR TITLE
Comment about client secrets

### DIFF
--- a/website/docs/r/application_password.html.markdown
+++ b/website/docs/r/application_password.html.markdown
@@ -9,7 +9,7 @@ description: |-
 
 # azuread_application_password
 
-Manages a Password associated with an Application within Azure Active Directory.
+Manages a Password associated with an Application within Azure Active Directory. Also can be referred to as Client secrets.
 
 -> **NOTE:** If you're authenticating using a Service Principal then it must have permissions to both `Read and write all applications` and `Sign in and read user profile` within the `Windows Azure Active Directory` API.
 


### PR DESCRIPTION
For beginners its quite usefull to know that application password is primarily named 'Client secrets' in the Azure management portal. It is stated that 'Client secrets' can be referred to as application password, but if you are not that familiar with the azure platform this might help someone out.

From the Azure portal:
![clientsecret](https://user-images.githubusercontent.com/36991168/84663760-e0e15e80-af1d-11ea-9ea0-0ca472992f89.png)
