### PR TITLE
azuread_application: no longer derive a default value for the homepage property

### DIFF
--- a/azuread/resource_application.go
+++ b/azuread/resource_application.go
@@ -58,7 +58,6 @@ func resourceApplication() *schema.Resource {
 			"homepage": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				Computed:     true,
 				ValidateFunc: validate.URLIsHTTPOrHTTPS,
 			},
 
@@ -316,11 +315,6 @@ func resourceApplicationCreate(d *schema.ResourceData, meta interface{}) error {
 
 	if v, ok := d.GetOk("homepage"); ok {
 		properties.Homepage = p.StringI(v)
-	} else {
-		// continue to automatically set the homepage with the type is not native
-		if appType != "native" {
-			properties.Homepage = p.String(fmt.Sprintf("https://%s", name))
-		}
 	}
 
 	if v, ok := d.GetOk("logout_url"); ok {

--- a/azuread/resource_application_test.go
+++ b/azuread/resource_application_test.go
@@ -28,7 +28,6 @@ func TestAccAzureADApplication_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckADApplicationExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", appName),
-					resource.TestCheckResourceAttr(resourceName, "homepage", fmt.Sprintf("https://%s", appName)),
 					resource.TestCheckResourceAttr(resourceName, "oauth2_allow_implicit_flow", "false"),
 					resource.TestCheckResourceAttr(resourceName, "type", "webapp/api"),
 					resource.TestCheckResourceAttr(resourceName, "oauth2_permissions.#", "1"),
@@ -60,7 +59,6 @@ func TestAccAzureADApplication_complete(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckADApplicationExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("acctest-APP-%[1]d", ri)),
-					resource.TestCheckResourceAttr(resourceName, "homepage", fmt.Sprintf("https://homepage-%d", ri)),
 					resource.TestCheckResourceAttr(resourceName, "oauth2_allow_implicit_flow", "true"),
 					resource.TestCheckResourceAttr(resourceName, "identifier_uris.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "identifier_uris.0", fmt.Sprintf("http://%d.hashicorptest.com/00000000-0000-0000-0000-00000000", ri)),
@@ -100,7 +98,6 @@ func TestAccAzureADApplication_update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckADApplicationExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("acctest-APP-%[1]d", ri)),
-					resource.TestCheckResourceAttr(resourceName, "homepage", fmt.Sprintf("https://acctest-APP-%d", ri)),
 					resource.TestCheckResourceAttr(resourceName, "identifier_uris.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "reply_urls.#", "0"),
 				),
@@ -115,7 +112,6 @@ func TestAccAzureADApplication_update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckADApplicationExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("acctest-APP-%[1]d", updatedri)),
-					resource.TestCheckResourceAttr(resourceName, "homepage", fmt.Sprintf("https://homepage-%d", updatedri)),
 					resource.TestCheckResourceAttr(resourceName, "identifier_uris.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "identifier_uris.0", fmt.Sprintf("http://%d.hashicorptest.com/00000000-0000-0000-0000-00000000", updatedri)),
 					resource.TestCheckResourceAttr(resourceName, "reply_urls.#", "1"),
@@ -151,7 +147,7 @@ func TestAccAzureADApplication_update(t *testing.T) {
 	})
 }
 
-func TestAccAzureADApplication_http_homepage(t *testing.T) {
+func TestAccAzureADApplication_https_homepage(t *testing.T) {
 	resourceName := "azuread_application.test"
 	ri := tf.AccRandTimeInt()
 
@@ -161,11 +157,11 @@ func TestAccAzureADApplication_http_homepage(t *testing.T) {
 		CheckDestroy: testCheckADApplicationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccADApplication_http_homepage(ri),
+				Config: testAccADApplication_https_homepage(ri),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckADApplicationExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("acctest-APP-%[1]d", ri)),
-					resource.TestCheckResourceAttr(resourceName, "homepage", fmt.Sprintf("http://homepage-%d", ri)),
+					resource.TestCheckResourceAttr(resourceName, "homepage", fmt.Sprintf("https://homepage-%d", ri)),
 					resource.TestCheckResourceAttr(resourceName, "oauth2_allow_implicit_flow", "false"),
 					resource.TestCheckResourceAttr(resourceName, "type", "webapp/api"),
 					resource.TestCheckResourceAttr(resourceName, "oauth2_permissions.#", "1"),
@@ -642,6 +638,7 @@ func testAccADApplication_basicEmpty(ri int) string {
 	return fmt.Sprintf(`
 resource "azuread_application" "test" {
   name                    = "acctest-APP-%[1]d"
+  homepage                = "https://homepage-%[1]d" // Cannot be unset once set, see https://github.com/Azure/azure-sdk-for-go/issues/10463
   identifier_uris         = []
   reply_urls              = []
   group_membership_claims = "None"
@@ -649,11 +646,11 @@ resource "azuread_application" "test" {
 `, ri)
 }
 
-func testAccADApplication_http_homepage(ri int) string {
+func testAccADApplication_https_homepage(ri int) string {
 	return fmt.Sprintf(`
 resource "azuread_application" "test" {
   name     = "acctest-APP-%[1]d"
-  homepage = "http://homepage-%[1]d"
+  homepage = "https://homepage-%[1]d"
 }
 `, ri)
 }

--- a/website/docs/r/application.html.markdown
+++ b/website/docs/r/application.html.markdown
@@ -109,7 +109,9 @@ The following arguments are supported:
 
 * `name` - (Required) The display name for the application.
 
-* `homepage` - (optional) The URL to the application's home page. If no homepage is specified this defaults to `https://{name}`.
+* `homepage` - (optional) The URL to the application's home page. This property is now also known as `signInUrl`.
+
+-> **NOTE:** The `homepage` (`signInUrl`) property no longer has a default value and must be set explicitly if needed. Also, due to API/SDK limitations, this property cannot be unset by Terraform once it has been set for an Application. This operation must be done manually in the Azure Portal, via the "Branding" blade for the Application.
 
 * `identifier_uris` - (Optional) A list of user-defined URI(s) that uniquely identify a Web application within it's Azure AD tenant, or within a verified custom domain if the application is multi-tenant.
 

--- a/website/docs/r/application.html.markdown
+++ b/website/docs/r/application.html.markdown
@@ -109,7 +109,7 @@ The following arguments are supported:
 
 * `name` - (Required) The display name for the application.
 
-* `homepage` - (optional) The URL to the application's home page. This property is now also known as `signInUrl`.
+* `homepage` - (optional) The URL to the application's home page.
 
 -> **NOTE:** The `homepage` (`signInUrl`) property no longer has a default value and must be set explicitly if needed. Also, due to API/SDK limitations, this property cannot be unset by Terraform once it has been set for an Application. This operation must be done manually in the Azure Portal, via the "Branding" blade for the Application.
 


### PR DESCRIPTION
- The homepage property (now known as 'signinUrl') used to be a required
  field with a default value when using the Azure Portal.
- It's no longer presented to the user when creating an application, and
  defaults to being unset (`null` in the application manifest)
- Also, it cannot currently be unset by the SDK once set. See https://github.com/Azure/azure-sdk-for-go/issues/10463

Mitigates, but does not solve: #268 
Related: https://github.com/Azure/azure-sdk-for-go/issues/10463