### PR TITLE
azuread_application & azuread_group: Duplicate name detection

### DIFF
--- a/azuread/helpers/graph/application.go
+++ b/azuread/helpers/graph/application.go
@@ -262,3 +262,31 @@ func ApplicationAddOwners(client graphrbac.ApplicationsClient, ctx context.Conte
 
 	return nil
 }
+
+func ApplicationFindByName(client graphrbac.ApplicationsClient, ctx context.Context, name string) (*graphrbac.Application, error) {
+	nameFilter := fmt.Sprintf("displayName eq '%s'", name)
+	resp, err := client.List(ctx, nameFilter)
+
+	if err != nil {
+		return nil, fmt.Errorf("unable to list Applications with filter %q: %+v", nameFilter, err)
+	}
+
+	for _, app := range resp.Values() {
+		if *app.DisplayName == name {
+			return &app, nil
+		}
+	}
+
+	return nil, nil
+}
+
+func ApplicationCheckNameAvailability(client graphrbac.ApplicationsClient, ctx context.Context, name string) error {
+	existingApp, err := ApplicationFindByName(client, ctx, name)
+	if err != nil {
+		return err
+	}
+	if existingApp != nil {
+		return fmt.Errorf("existing Application with name %q (AppID: %q) was found and `prevent_duplicate_names` was specified", name, *existingApp.AppID)
+	}
+	return nil
+}

--- a/website/docs/r/application.html.markdown
+++ b/website/docs/r/application.html.markdown
@@ -137,6 +137,8 @@ The following arguments are supported:
 
 * `oauth2_permissions` - (Optional) A collection of OAuth 2.0 permission scopes that the web API (resource) app exposes to client apps. Each permission is covered by `oauth2_permissions` blocks as documented below.
 
+* `prevent_duplicate_names` - (Optional) If `true`, will return an error when an existing Application is found with the same name. Defaults to `false`.
+
 ---
 
 `required_resource_access` supports the following:

--- a/website/docs/r/group.markdown
+++ b/website/docs/r/group.markdown
@@ -49,6 +49,7 @@ The following arguments are supported:
 * `description` - (Optional) The description for the Group.  Changing this forces a new resource to be created.
 * `members` (Optional) A set of members who should be present in this Group. Supported Object types are Users, Groups or Service Principals.
 * `owners` (Optional) A set of owners who own this Group. Supported Object types are Users or Service Principals.
+* `prevent_duplicate_names` - (Optional) If `true`, will return an error when an existing Group is found with the same name. Defaults to `false`.
 
 -> **NOTE:** Group names are not unique within Azure Active Directory.
 


### PR DESCRIPTION
- New property `prevent_duplicate_names`, defaults to false
- When true, searches for an existing application / group and errs if one found having the same name
- For applications, also performs the check on update

Closes: #182, #200