### PR TITLE
azuread_group: remediate replication delays when adding/removing group members

### DIFF
--- a/azuread/helpers/graph/group.go
+++ b/azuread/helpers/graph/group.go
@@ -134,7 +134,7 @@ func GroupAddMember(client graphrbac.GroupsClient, ctx context.Context, groupId 
 		time.Sleep(time.Second * 2)
 	}
 
-	if _, err := WaitForListMember(member, func() ([]string, error) {
+	if _, err := WaitForListAdd(member, func() ([]string, error) {
 		return GroupAllMembers(client, ctx, groupId)
 	}); err != nil {
 		return fmt.Errorf("Error waiting for group membership: %+v", err)

--- a/azuread/helpers/graph/group.go
+++ b/azuread/helpers/graph/group.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/graphrbac/1.6/graphrbac"
 )
@@ -121,8 +122,22 @@ func GroupAddMember(client graphrbac.GroupsClient, ctx context.Context, groupId 
 	}
 
 	log.Printf("[DEBUG] Adding member with id %q to Azure AD group with id %q", member, groupId)
-	if _, err := client.AddMember(ctx, groupId, properties); err != nil {
-		return fmt.Errorf("Error adding group member %q to Azure AD Group with ID %q: %+v", member, groupId, err)
+	var err error
+	attempts := 10
+	for i := 0; i <= attempts; i++ {
+		if _, err = client.AddMember(ctx, groupId, properties); err == nil {
+			break
+		}
+		if i == attempts {
+			return fmt.Errorf("Error adding group member %q to Azure AD Group with ID %q: %+v", member, groupId, err)
+		}
+		time.Sleep(time.Second * 2)
+	}
+
+	if _, err := WaitForListMember(member, func() ([]string, error) {
+		return GroupAllMembers(client, ctx, groupId)
+	}); err != nil {
+		return fmt.Errorf("Error waiting for group membership: %+v", err)
 	}
 
 	return nil

--- a/azuread/helpers/graph/replication.go
+++ b/azuread/helpers/graph/replication.go
@@ -34,3 +34,28 @@ func WaitForCreationReplication(f func() (interface{}, error)) (interface{}, err
 		},
 	}).WaitForState()
 }
+
+func WaitForListMember(member string, f func() ([]string, error)) (interface{}, error) {
+	return (&resource.StateChangeConf{
+		Pending:                   []string{"404"},
+		Target:                    []string{"Found"},
+		Timeout:                   5 * time.Minute,
+		MinTimeout:                1 * time.Second,
+		ContinuousTargetOccurence: 10,
+		Refresh: func() (interface{}, string, error) {
+			members, err := f()
+
+			if err != nil {
+				return members, "Error", err
+			}
+
+			for _, v := range members {
+				if v == member {
+					return members, "Found", nil
+				}
+			}
+
+			return members, "404", nil
+		},
+	}).WaitForState()
+}

--- a/azuread/helpers/graph/replication.go
+++ b/azuread/helpers/graph/replication.go
@@ -35,7 +35,7 @@ func WaitForCreationReplication(f func() (interface{}, error)) (interface{}, err
 	}).WaitForState()
 }
 
-func WaitForListMember(member string, f func() ([]string, error)) (interface{}, error) {
+func WaitForListAdd(item string, f func() ([]string, error)) (interface{}, error) {
 	return (&resource.StateChangeConf{
 		Pending:                   []string{"404"},
 		Target:                    []string{"Found"},
@@ -43,19 +43,44 @@ func WaitForListMember(member string, f func() ([]string, error)) (interface{}, 
 		MinTimeout:                1 * time.Second,
 		ContinuousTargetOccurence: 10,
 		Refresh: func() (interface{}, string, error) {
-			members, err := f()
+			listItems, err := f()
 
 			if err != nil {
-				return members, "Error", err
+				return listItems, "Error", err
 			}
 
-			for _, v := range members {
-				if v == member {
-					return members, "Found", nil
+			for _, v := range listItems {
+				if v == item {
+					return listItems, "Found", nil
 				}
 			}
 
-			return members, "404", nil
+			return listItems, "404", nil
+		},
+	}).WaitForState()
+}
+
+func WaitForListRemove(item string, f func() ([]string, error)) (interface{}, error) {
+	return (&resource.StateChangeConf{
+		Pending:                   []string{"Found"},
+		Target:                    []string{"404"},
+		Timeout:                   5 * time.Minute,
+		MinTimeout:                1 * time.Second,
+		ContinuousTargetOccurence: 10,
+		Refresh: func() (interface{}, string, error) {
+			listItems, err := f()
+
+			if err != nil {
+				return listItems, "Error", err
+			}
+
+			for _, v := range listItems {
+				if v == item {
+					return listItems, "Found", nil
+				}
+			}
+
+			return listItems, "404", nil
 		},
 	}).WaitForState()
 }

--- a/azuread/resource_group.go
+++ b/azuread/resource_group.go
@@ -3,8 +3,10 @@ package azuread
 import (
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/graphrbac/1.6/graphrbac"
+	"github.com/Azure/go-autorest/autorest"
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
@@ -186,11 +188,26 @@ func resourceGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 		membersToAdd := slices.Difference(desiredMembers, existingMembers)
 
 		for _, existingMember := range membersForRemoval {
+			var err error
+			var resp autorest.Response
 			log.Printf("[DEBUG] Removing member with id %q from Azure AD group with id %q", existingMember, d.Id())
-			if resp, err := client.RemoveMember(ctx, d.Id(), existingMember); err != nil {
-				if !ar.ResponseWasNotFound(resp) {
+			attempts := 10
+			for i := 0; i <= attempts; i++ {
+				if resp, err = client.RemoveMember(ctx, d.Id(), existingMember); err != nil {
+					if ar.ResponseWasNotFound(resp) {
+						break
+					}
+				}
+				if i == attempts {
 					return fmt.Errorf("Error Deleting group member %q from Azure AD Group with ID %q: %+v", existingMember, d.Id(), err)
 				}
+				time.Sleep(time.Second * 2)
+			}
+
+			if _, err := graph.WaitForListRemove(existingMember, func() ([]string, error) {
+				return graph.GroupAllMembers(client, ctx, d.Id())
+			}); err != nil {
+				return fmt.Errorf("Error waiting for group membership removal: %+v", err)
 			}
 		}
 


### PR DESCRIPTION
1. Attempt up to 10 times to add a group member with fixed 2 second backoff
2. Ensure 10 affirmative responses when retrieving group members after adding
3. Attempt up to 10 times to remove a group member with fixed 2 second backoff
4. Ensure 10 affirmative responses when retrieving group members after removing

**Fixes:**
> Error adding group member "62a54f8c-eef7-4106-9989-aa9018f46a98" to Azure AD Group with ID "d8c4d6c5-7d04-4865-85a6-cf311f1a619c": graphrbac.GroupsClient#AddMember: Failure responding to request: StatusCode=400 -- Original Error: autorest/azure: Service returned an error. Status=400 Code="Unknown" Message="Unknown service error" Details=[{"odata.error":{"code":"Request_BadRequest","date":"2020-06-17T02:03:42","message":{"lang":"en","value":"One or more added object references already exist for the following modified properties: 'members'."},"requestId":"aaa440fc-7671-4d5d-b353-f599f1335ae5"}}]

>Error Deleting group member "ecd616ca-06e3-4c36-9932-ecfeef38ffe6" from Azure AD Group with ID "c7196f3e-5d41-4726-8293-873712dd9830": graphrbac.GroupsClient#RemoveMember: Failure responding to request: StatusCode=400 -- Original Error: autorest/azure: Service returned an error. Status=400 Code="Unknown" Message="Unknown service error" Details=[{"odata.error":{"code":"Request_BadRequest","date":"2020-06-17T23:17:44","message":{"lang":"en","value":"One or more removed object references do not exist for the following modified properties: 'members'."},"requestId":"c690ded0-7a1f-4079-9717-c857d3513e23"}}]
