### PR TITLE
azuread_application: validate values for app_role and oauth2_permissions to screen for duplicates

### DIFF
--- a/website/docs/r/application.html.markdown
+++ b/website/docs/r/application.html.markdown
@@ -137,6 +137,8 @@ The following arguments are supported:
 
 * `oauth2_permissions` - (Optional) A collection of OAuth 2.0 permission scopes that the web API (resource) app exposes to client apps. Each permission is covered by `oauth2_permissions` blocks as documented below.
 
+-> **Note on roles and scopes/permissions:** in Azure Active Directory, roles (`app_role`) and scopes/permissions (`oauth2_permissions`) exported by an Application share the same namespace and cannot contain duplicate values. Terraform will attempt to detect this at plan time.
+
 * `prevent_duplicate_names` - (Optional) If `true`, will return an error when an existing Application is found with the same name. Defaults to `false`.
 
 ---


### PR DESCRIPTION
Roles (appRoles) and scopes (oauth2Permissions) exposed by an application share a common namespace where the values cannot overlap. This change adds some local validation to screen for these before PATCHing an application.

Changes the resulting error message from this:
```
Error: patching Azure AD Application with ID "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee": graphrbac.ApplicationsClient#Patch: Failure responding to request: StatusCode=400 -- Original Error: autorest/azure: Service returned an error. Status=400 Code="Unknown" Message="Unknown service error" Details=[{"odata.error":{"code":"Request_BadRequest","date":"2020-06-09T10:06:21","message":{"lang":"en","value":"Request contains a property with duplicate values."},"requestId":"dab8185c-239f-44dd-8ca3-8bd13e3e67b3","values":[{"item":"PropertyName","value":"oauth2Permissions"},{"item":"PropertyErrorCode","value":"DuplicateValue"}]}}]
```

to this:
```
Error: validation failed: duplicate app_role / oauth2_permissions value found: "administer"
```

Closes: #269