### PR TITLE
Fix nil pointer dereference in data.azuread_users and improve test coverage

### DIFF
--- a/azuread/data_user.go
+++ b/azuread/data_user.go
@@ -6,6 +6,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/graphrbac/1.6/graphrbac"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 
+	"github.com/terraform-providers/terraform-provider-azuread/azuread/helpers/ar"
 	"github.com/terraform-providers/terraform-provider-azuread/azuread/helpers/graph"
 	"github.com/terraform-providers/terraform-provider-azuread/azuread/helpers/validate"
 )
@@ -89,19 +90,28 @@ func dataSourceUserRead(d *schema.ResourceData, meta interface{}) error {
 	if upn, ok := d.Get("user_principal_name").(string); ok && upn != "" {
 		resp, err := client.Get(ctx, upn)
 		if err != nil {
-			return fmt.Errorf("Error making Read request on AzureAD User with ID %q: %+v", upn, err)
+			if ar.ResponseWasNotFound(resp.Response) {
+				return fmt.Errorf("Azure AD User not found with UPN: %q", upn)
+			}
+			return fmt.Errorf("making Read request on AzureAD User with ID %q: %+v", upn, err)
 		}
 		user = resp
 	} else if oId, ok := d.Get("object_id").(string); ok && oId != "" {
 		u, err := graph.UserGetByObjectId(&client, ctx, oId)
 		if err != nil {
-			return fmt.Errorf("Error finding Azure AD User with object ID %q: %+v", oId, err)
+			return fmt.Errorf("finding Azure AD User with object ID %q: %+v", oId, err)
+		}
+		if u == nil {
+			return fmt.Errorf("Azure AD User not found with object ID: %q", oId)
 		}
 		user = *u
 	} else if mailNickname, ok := d.Get("mail_nickname").(string); ok && mailNickname != "" {
 		u, err := graph.UserGetByMailNickname(&client, ctx, mailNickname)
 		if err != nil {
-			return fmt.Errorf("Error finding Azure AD User with email alias %q: %+v", mailNickname, err)
+			return fmt.Errorf("finding Azure AD User with email alias %q: %+v", mailNickname, err)
+		}
+		if u == nil {
+			return fmt.Errorf("Azure AD User not found with email alias: %q", mailNickname)
 		}
 		user = *u
 	} else {

--- a/azuread/data_user_test.go
+++ b/azuread/data_user_test.go
@@ -2,6 +2,7 @@ package azuread
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
@@ -32,6 +33,21 @@ func TestAccAzureADUserDataSource_byUserPrincipalName(t *testing.T) {
 	})
 }
 
+func TestAccAzureADUserDataSource_byUserPrincipalNameNonexistent(t *testing.T) {
+	ri := tf.AccRandTimeInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAzureADUserDataSource_byUserPrincipalNameNonexistent(ri),
+				ExpectError: regexp.MustCompile("Azure AD User not found with UPN:"),
+			},
+		},
+	})
+}
+
 func TestAccAzureADUserDataSource_byObjectId(t *testing.T) {
 	dsn := "data.azuread_user.test"
 	id := tf.AccRandTimeInt()
@@ -49,6 +65,19 @@ func TestAccAzureADUserDataSource_byObjectId(t *testing.T) {
 					resource.TestCheckResourceAttrSet(dsn, "display_name"),
 					resource.TestCheckResourceAttrSet(dsn, "mail_nickname"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccAzureADUserDataSource_byObjectIdNonexistent(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAzureADUserDataSource_byObjectIdNonexistent(),
+				ExpectError: regexp.MustCompile("Azure AD User not found with object ID:"),
 			},
 		},
 	})
@@ -76,6 +105,21 @@ func TestAccAzureADUserDataSource_byMailNickname(t *testing.T) {
 	})
 }
 
+func TestAccAzureADUserDataSource_byMailNicknameNonexistent(t *testing.T) {
+	ri := tf.AccRandTimeInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAzureADUserDataSource_byMailNicknameNonexistent(ri),
+				ExpectError: regexp.MustCompile("Azure AD User not found with email alias:"),
+			},
+		},
+	})
+}
+
 func testAccAzureADUserDataSource_byUserPrincipalName(id int, password string) string {
 	return fmt.Sprintf(`
 %s
@@ -84,6 +128,18 @@ data "azuread_user" "test" {
   user_principal_name = azuread_user.test.user_principal_name
 }
 `, testAccADUser_basic(id, password))
+}
+
+func testAccAzureADUserDataSource_byUserPrincipalNameNonexistent(ri int) string {
+	return fmt.Sprintf(`
+data "azuread_domains" "tenant_domain" {
+  only_initial = true
+}
+
+data "azuread_user" "test" {
+  user_principal_name = "not-a-real-user-%d${data.azuread_domains.tenant_domain.domains.0.domain_name}"
+}
+`, ri)
 }
 
 func testAccAzureADUserDataSource_byObjectId(id int, password string) string {
@@ -96,6 +152,14 @@ data "azuread_user" "test" {
 `, testAccADUser_basic(id, password))
 }
 
+func testAccAzureADUserDataSource_byObjectIdNonexistent() string {
+	return `
+data "azuread_user" "test" {
+  object_id = "00000000-0000-0000-0000-000000000000"
+}
+`
+}
+
 func testAccAzureADUserDataSource_byMailNickname(id int, password string) string {
 	return fmt.Sprintf(`
 %s
@@ -104,4 +168,16 @@ data "azuread_user" "test" {
   mail_nickname = azuread_user.test.mail_nickname
 }
 `, testAccADUser_basic(id, password))
+}
+
+func testAccAzureADUserDataSource_byMailNicknameNonexistent(ri int) string {
+	return fmt.Sprintf(`
+data "azuread_domains" "tenant_domain" {
+  only_initial = true
+}
+
+data "azuread_user" "test" {
+  mail_nickname = "not-a-real-user-%d${data.azuread_domains.tenant_domain.domains.0.domain_name}"
+}
+`, ri)
 }

--- a/azuread/data_users_test.go
+++ b/azuread/data_users_test.go
@@ -31,6 +31,28 @@ func TestAccAzureADUsersDataSource_byUserPrincipalNames(t *testing.T) {
 	})
 }
 
+func TestAccAzureADUsersDataSource_byUserPrincipalNamesIgnoreMissing(t *testing.T) {
+	dsn := "data.azuread_users.test"
+	id := tf.AccRandTimeInt()
+	password := "p@$$wR2" + acctest.RandStringFromCharSet(7, acctest.CharSetAlphaNum)
+	ri := tf.AccRandTimeInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureADUsersDataSource_byUserPrincipalNamesIgnoreMissing(id, password, ri),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dsn, "user_principal_names.#", "3"),
+					resource.TestCheckResourceAttr(dsn, "object_ids.#", "3"),
+					resource.TestCheckResourceAttr(dsn, "users.#", "3"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAzureADUsersDataSource_byObjectIds(t *testing.T) {
 	dsn := "data.azuread_users.test"
 	id := tf.AccRandTimeInt()
@@ -42,6 +64,27 @@ func TestAccAzureADUsersDataSource_byObjectIds(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAzureADUsersDataSource_byObjectIds(id, password),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dsn, "user_principal_names.#", "2"),
+					resource.TestCheckResourceAttr(dsn, "object_ids.#", "2"),
+					resource.TestCheckResourceAttr(dsn, "users.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureADUsersDataSource_byObjectIdsIgnoreMissing(t *testing.T) {
+	dsn := "data.azuread_users.test"
+	id := tf.AccRandTimeInt()
+	password := "p@$$wR2" + acctest.RandStringFromCharSet(7, acctest.CharSetAlphaNum)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureADUsersDataSource_byObjectIdsIgnoreMissing(id, password),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dsn, "user_principal_names.#", "2"),
 					resource.TestCheckResourceAttr(dsn, "object_ids.#", "2"),
@@ -74,6 +117,29 @@ func TestAccAzureADUsersDataSource_byMailNicknames(t *testing.T) {
 	})
 }
 
+func TestAccAzureADUsersDataSource_byMailNicknamesIgnoreMissing(t *testing.T) {
+	dsn := "data.azuread_users.test"
+	id := tf.AccRandTimeInt()
+	password := "p@$$wR2" + acctest.RandStringFromCharSet(7, acctest.CharSetAlphaNum)
+	ri := tf.AccRandTimeInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureADUsersDataSource_byMailNicknamesIgnoreMissing(id, password, ri),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dsn, "user_principal_names.#", "2"),
+					resource.TestCheckResourceAttr(dsn, "object_ids.#", "2"),
+					resource.TestCheckResourceAttr(dsn, "mail_nicknames.#", "2"),
+					resource.TestCheckResourceAttr(dsn, "users.#", "2"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAzureADUsersDataSource_noNames(t *testing.T) {
 	dsn := "data.azuread_users.test"
 
@@ -93,28 +159,6 @@ func TestAccAzureADUsersDataSource_noNames(t *testing.T) {
 	})
 }
 
-func TestAccAzureADUsersDataSource_ignoreMissing(t *testing.T) {
-	dsn := "data.azuread_users.test"
-	id := tf.AccRandTimeInt()
-	password := "p@$$wR2" + acctest.RandStringFromCharSet(7, acctest.CharSetAlphaNum)
-	ri := tf.AccRandTimeInt()
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAzureADUsersDataSource_ignoreMissing(id, password, ri),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(dsn, "user_principal_names.#", "3"),
-					resource.TestCheckResourceAttr(dsn, "object_ids.#", "3"),
-					resource.TestCheckResourceAttr(dsn, "users.#", "3"),
-				),
-			},
-		},
-	})
-}
-
 func testAccAzureADUsersDataSource_byUserPrincipalNames(id int, password string) string {
 	return fmt.Sprintf(`
 %s
@@ -125,35 +169,7 @@ data "azuread_users" "test" {
 `, testAccADUser_threeUsersABC(id, password))
 }
 
-func testAccAzureADUsersDataSource_byObjectIds(id int, password string) string {
-	return fmt.Sprintf(`
-%s
-
-data "azuread_users" "test" {
-  object_ids = [azuread_user.testA.object_id, azuread_user.testB.object_id]
-}
-`, testAccADUser_threeUsersABC(id, password))
-}
-
-func testAccAzureADUsersDataSource_byMailNicknames(id int, password string) string {
-	return fmt.Sprintf(`
-%s
-
-data "azuread_users" "test" {
-  mail_nicknames = [azuread_user.testA.mail_nickname, azuread_user.testB.mail_nickname]
-}
-`, testAccADUser_threeUsersABC(id, password))
-}
-
-func testAccAzureADUsersDataSource_noNames() string {
-	return `
-data "azuread_users" "test" {
-  user_principal_names = []
-}
-`
-}
-
-func testAccAzureADUsersDataSource_ignoreMissing(id int, password string, ri int) string {
+func testAccAzureADUsersDataSource_byUserPrincipalNamesIgnoreMissing(id int, password string, ri int) string {
 	return fmt.Sprintf(`
 %s
 
@@ -168,4 +184,64 @@ data "azuread_users" "test" {
   ]
 }
 `, testAccADUser_threeUsersABC(id, password), ri)
+}
+
+func testAccAzureADUsersDataSource_byObjectIds(id int, password string) string {
+	return fmt.Sprintf(`
+%s
+
+data "azuread_users" "test" {
+  object_ids = [azuread_user.testA.object_id, azuread_user.testB.object_id]
+}
+`, testAccADUser_threeUsersABC(id, password))
+}
+
+func testAccAzureADUsersDataSource_byObjectIdsIgnoreMissing(id int, password string) string {
+	return fmt.Sprintf(`
+%s
+
+data "azuread_users" "test" {
+  ignore_missing = true
+
+  object_ids = [
+    azuread_user.testA.object_id,
+    azuread_user.testB.object_id,
+    "00000000-0000-0000-0000-000000000000"
+  ]
+}
+`, testAccADUser_threeUsersABC(id, password))
+}
+
+func testAccAzureADUsersDataSource_byMailNicknames(id int, password string) string {
+	return fmt.Sprintf(`
+%s
+
+data "azuread_users" "test" {
+  mail_nicknames = [azuread_user.testA.mail_nickname, azuread_user.testB.mail_nickname]
+}
+`, testAccADUser_threeUsersABC(id, password))
+}
+
+func testAccAzureADUsersDataSource_byMailNicknamesIgnoreMissing(id int, password string, ri int) string {
+	return fmt.Sprintf(`
+%s
+
+data "azuread_users" "test" {
+  ignore_missing = true
+
+  mail_nicknames = [
+    azuread_user.testA.mail_nickname,
+    azuread_user.testB.mail_nickname,
+    "not-a-real-user-%d${data.azuread_domains.tenant_domain.domains.0.domain_name}"
+  ]
+}
+`, testAccADUser_threeUsersABC(id, password), ri)
+}
+
+func testAccAzureADUsersDataSource_noNames() string {
+	return `
+data "azuread_users" "test" {
+  user_principal_names = []
+}
+`
 }

--- a/azuread/helpers/graph/user.go
+++ b/azuread/helpers/graph/user.go
@@ -5,13 +5,18 @@ import (
 	"fmt"
 
 	"github.com/Azure/azure-sdk-for-go/services/graphrbac/1.6/graphrbac"
+
+	"github.com/terraform-providers/terraform-provider-azuread/azuread/helpers/ar"
 )
 
 func UserGetByObjectId(client *graphrbac.UsersClient, ctx context.Context, objectId string) (*graphrbac.User, error) {
 	filter := fmt.Sprintf("objectId eq '%s'", objectId)
 	resp, err := client.ListComplete(ctx, filter, "")
 	if err != nil {
-		return nil, fmt.Errorf("Error listing Azure AD Users for filter %q: %+v", filter, err)
+		if ar.ResponseWasNotFound(resp.Response().Response) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("listing Azure AD Users for filter %q: %+v", filter, err)
 	}
 
 	values := resp.Response().Value
@@ -19,10 +24,10 @@ func UserGetByObjectId(client *graphrbac.UsersClient, ctx context.Context, objec
 		return nil, fmt.Errorf("nil values for AD Users matching %q", filter)
 	}
 	if len(*values) == 0 {
-		return nil, fmt.Errorf("Found no AD Users matching %q", filter)
+		return nil, nil
 	}
 	if len(*values) > 2 {
-		return nil, fmt.Errorf("Found multiple AD Users matching %q", filter)
+		return nil, fmt.Errorf("found multiple AD Users matching %q", filter)
 	}
 
 	user := (*values)[0]
@@ -40,7 +45,7 @@ func UserGetByMailNickname(client *graphrbac.UsersClient, ctx context.Context, m
 	filter := fmt.Sprintf("mailNickname eq '%s'", mailNickname)
 	resp, err := client.ListComplete(ctx, filter, "")
 	if err != nil {
-		return nil, fmt.Errorf("Error listing Azure AD Users for filter %q: %+v", filter, err)
+		return nil, fmt.Errorf("listing Azure AD Users for filter %q: %+v", filter, err)
 	}
 
 	values := resp.Response().Value
@@ -48,10 +53,10 @@ func UserGetByMailNickname(client *graphrbac.UsersClient, ctx context.Context, m
 		return nil, fmt.Errorf("nil values for AD Users matching %q", filter)
 	}
 	if len(*values) == 0 {
-		return nil, fmt.Errorf("Found no AD Users matching %q", filter)
+		return nil, nil
 	}
 	if len(*values) > 2 {
-		return nil, fmt.Errorf("Found multiple AD Users matching %q", filter)
+		return nil, fmt.Errorf("found multiple AD Users matching %q", filter)
 	}
 
 	user := (*values)[0]


### PR DESCRIPTION
- Better test coverage in `data.azuread_user` and `data.azuread_users`.
- Prettier errors when users not found.
- Fix nil pointer dereference due to mishandling of search results (reported: https://github.com/terraform-providers/terraform-provider-azuread/pull/256#issuecomment-651645643)