### PR TITLE
updated to latest azuread and changed existing group error to warning

### DIFF
--- a/azuread/helpers/graph/group.go
+++ b/azuread/helpers/graph/group.go
@@ -221,7 +221,7 @@ func GroupCheckNameAvailability(client graphrbac.GroupsClient, ctx context.Conte
 		return err
 	}
 	if existingGroup != nil {
-		return fmt.Errorf("existing Azure Active Directory Group with name %q (ObjID: %q) was found and `prevent_duplicate_names` was specified", name, *existingGroup.ObjectID)
+		return fmt.Warnf("existing Azure Active Directory Group with name %q (ObjID: %q) was found and `prevent_duplicate_names` was specified", name, *existingGroup.ObjectID)
 	}
 	return nil
 }


### PR DESCRIPTION
If youve selected `prevent_duplicate_names` you are expecting there to be an already existing group.
In my scenario, my terraform is being deployed via a CICD pipeline and the error breaks the pipeline.

If you are managing groups in terraform, then the existing group should look exactly like the one you are trying to create.
The only place an error make sense if you are trying to create a group that isnt managed outside of terraform.

If you have further dependencies on a group down the line, then your terraform still wont work, regardless of a warning or an error message.