### PR TITLE
azuread_application: Adding signInAudience field

### DIFF
--- a/website/docs/r/application.html.markdown
+++ b/website/docs/r/application.html.markdown
@@ -141,6 +141,8 @@ The following arguments are supported:
 
 * `prevent_duplicate_names` - (Optional) If `true`, will return an error when an existing Application is found with the same name. Defaults to `false`.
 
+* `sign_in_audience` - (Optional) Type of an audience: `AzureADMyOrg`, `AzureADMultipleOrgs` or `AzureADandPersonalMicrosoftAccount`, will return an error when updated on an existing application due to restrictions per audience. For more information https://docs.microsoft.com/en-us/azure/active-directory/develop/supported-accounts-validation. Defaults to `AzureADMyOrg`.
+
 ---
 
 `required_resource_access` supports the following:


### PR DESCRIPTION
I'm trying to solve #208 by adding a `sign_in_audience` field to enable users to declare the audience type when creating an `azuread_application` resource.

As specified in the documentation updating this value on an existing resource is not advised due to different constraints per audience type. Therefor an error will be thrown when updating the `sign_in_audience` field.

The test ran successfully, but I'm not sure my setup was correct so please verify.

A question about testing the changes. Is there a possibility/documentation on how to use the the Terraform provider with the changes locally with my own scripts?

Since this is my first time with `golang`, so please let me know if there are improvements. 