### PR TITLE
remove reference to subscription_id in provider doc

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -83,8 +83,6 @@ The following arguments are supported:
 
 * `environment` - (Optional) The Cloud Environment which be used. Possible values are `public`, `usgovernment`, `german` and `china`. Defaults to `public`. This can also be sourced from the `ARM_ENVIRONMENT` environment variable.
 
-* `subscription_id` - (Optional) The Subscription ID which should be used. This can also be sourced from the `ARM_SUBSCRIPTION_ID` Environment Variable.
-
 * `tenant_id` - (Optional) The Tenant ID which should be used. This can also be sourced from the `ARM_TENANT_ID` Environment Variable.
 
 ---


### PR DESCRIPTION
Version 1.0.0 removed the `subscription_id` argument for configuring the azuread provider, which causes an error if you configured that previously. It was a bit confusing to reference the documentation and see that it was still an optional argument.
```
Error: Unsupported argument

  on providers.tf line 37, in provider "azuread":
  37:   subscription_id = var.azure-infra-subscription-id

An argument named "subscription_id" is not expected here.
```

This PR removes the reference to that configuration option in the website doc.