### PR TITLE
Add group availability data source

### DIFF
--- a/internal/services/aadgraph/0registration.go
+++ b/internal/services/aadgraph/0registration.go
@@ -21,14 +21,15 @@ func (r Registration) WebsiteCategories() []string {
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{
-		"azuread_application":       applicationData(),
-		"azuread_domains":           domainsData(),
-		"azuread_client_config":     clientConfigData(),
-		"azuread_group":             groupData(),
-		"azuread_groups":            groupsData(),
-		"azuread_service_principal": servicePrincipalData(),
-		"azuread_user":              userData(),
-		"azuread_users":             usersData(),
+		"azuread_application":        applicationData(),
+		"azuread_domains":            domainsData(),
+		"azuread_client_config":      clientConfigData(),
+		"azuread_group":              groupData(),
+		"azuread_group_availability": groupAvailabilityData(),
+		"azuread_groups":             groupsData(),
+		"azuread_service_principal":  servicePrincipalData(),
+		"azuread_user":               userData(),
+		"azuread_users":              usersData(),
 	}
 }
 

--- a/internal/services/aadgraph/group_availability_data_source.go
+++ b/internal/services/aadgraph/group_availability_data_source.go
@@ -1,0 +1,47 @@
+package aadgraph
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+
+	"github.com/terraform-providers/terraform-provider-azuread/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azuread/internal/services/aadgraph/graph"
+)
+
+func groupAvailabilityData() *schema.Resource {
+	return &schema.Resource{
+		Read: groupAvailabilityDataRead,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.NoZeroValues,
+			},
+		},
+	}
+}
+
+func groupAvailabilityDataRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.AadClient).AadGraph.GroupsClient
+	ctx := meta.(*clients.AadClient).StopContext
+
+	name := d.Get("name").(string)
+
+	existingGroup, err := graph.GroupFindByName(ctx, client, name)
+	if err != nil {
+		return err
+	}
+	if existingGroup != nil {
+		return fmt.Errorf("existing Group with name %q (ID: %q) was found", name, *existingGroup.ObjectID)
+	}
+
+	d.SetId(fmt.Sprintf("%s:availability", name))
+
+	return nil
+}


### PR DESCRIPTION
Adds a data source which will cause an error if the specified group name
exists within AzureAD. This resolves the issue of group resource only
failing on apply when using "prevent_duplicate_names".

If there is a better way, I'm all ears.