### PR TITLE
Allow id on app_role block

### DIFF
--- a/internal/services/aadgraph/application_resource.go
+++ b/internal/services/aadgraph/application_resource.go
@@ -115,6 +115,7 @@ func applicationResource() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"id": {
 							Type:     schema.TypeString,
+							Optional: true,
 							Computed: true,
 						},
 


### PR DESCRIPTION
Hi,

I propose this quick merge to allow the use of an not computed ID for the the block app_role {} in the azure_application ressource.

Why ?
In my case, I have more than 500 app_role to setup, that's why the app_role resource is not the right choice for me.

How ?

```
resource "azuread_application" "this" {
  name            = "AWS"
  identifier_uris = ["urn:amazon:webservices"]
  reply_urls      = ["https://signin.aws.amazon.com/saml"]
  type            = "webapp/api"


  dynamic "app_role" {
    for_each = local.unique_roles
    content {
      id = uuidv5("url", app_role.value)
      allowed_member_types = [
        "User",
      ]
      description  = app_role.value
      display_name = app_role.value
      is_enabled   = true
      value        = "arn:aws:iam::${split(":", app_role.value)[0]}:role/${split(":", app_role.value)[1]},arn:aws:iam::${split(":", app_role.value)[0]}:saml-provider/AZUREAD"
    }
  }

  lifecycle {
    ignore_changes = [required_resource_access, owners]
  }
}

resource "restapi_object" "approle_assignement" {
  depends_on = [
    azuread_application.this
  ]
  for_each = local.role_mapping
  force_new = [
    each.key,
  ]
  path = "/v1.0/servicePrincipals/${azuread_service_principal.this.object_id}/appRoleAssignedTo"
  data = jsonencode({
    "principalId": each.value.group_id
    "resourceId": azuread_service_principal.this.object_id,
    "appRoleId": uuidv5("url", each.value.app_role_description)
  })
}
```

Thanks,
Benoit