### PR TITLE
azuread_application: revert #355 but retain tests, must retain default application owner at create time

### DIFF
--- a/internal/services/aadgraph/application_resource.go
+++ b/internal/services/aadgraph/application_resource.go
@@ -403,7 +403,7 @@ func applicationResourceCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// there is a default owner that we must account so use this shared function
-	if v, ok := d.GetOkExists("owners"); ok {
+	if v, ok := d.GetOk("owners"); ok {
 		desiredOwners := *tf.ExpandStringSlicePtr(v.(*schema.Set).List())
 		if err := applicationSetOwnersTo(ctx, client, *app.ObjectID, desiredOwners); err != nil {
 			return err

--- a/internal/services/aadgraph/application_resource_test.go
+++ b/internal/services/aadgraph/application_resource_test.go
@@ -532,6 +532,14 @@ func TestAccApplication_ownersUpdate(t *testing.T) {
 		CheckDestroy: testCheckApplicationDestroy,
 		Steps: []resource.TestStep{
 			{
+				Config: testAccApplication_basic(data.RandomInteger),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckApplicationExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "owners.#", "1"),
+				),
+			},
+			data.ImportStep(),
+			{
 				Config: testAccApplication_removeOwners(data.RandomInteger, pw),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckApplicationExists(data.ResourceName),


### PR DESCRIPTION
Reverts #355 

Whilst we want to enable application owners to be empty at create time, this cannot be done whilst also having the ability to retain the default owner assigned by Azure AD.

With this fix, the following applies:
- Default application owner is retained at create time
- Default owner can be overridden with one or more specified owners
- Owners cannot be forced empty at create time
- Owners can be forced empty on subsequent applies, with the caveat that Terraform must detect a config change

Fixes #365