### PR TITLE
azuread_application: avoid update after create

### DIFF
--- a/internal/services/aadgraph/application_resource.go
+++ b/internal/services/aadgraph/application_resource.go
@@ -605,9 +605,11 @@ func applicationResourceRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("setting `owners`: %+v", err)
 	}
 
-	if preventDuplicates := d.Get("prevent_duplicate_names").(bool); !preventDuplicates {
-		d.Set("prevent_duplicate_names", false)
+	preventDuplicates := false
+	if v := d.Get("prevent_duplicate_names").(bool); v {
+		preventDuplicates = v
 	}
+	d.Set("prevent_duplicate_names", preventDuplicates)
 
 	return nil
 }

--- a/internal/services/aadgraph/application_resource_test.go
+++ b/internal/services/aadgraph/application_resource_test.go
@@ -246,6 +246,14 @@ func TestAccApplication_appRolesUpdate(t *testing.T) {
 		CheckDestroy: testCheckApplicationDestroy,
 		Steps: []resource.TestStep{
 			{
+				Config: testAccApplication_basic(data.RandomInteger),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckApplicationExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "app_role.#", "0"),
+				),
+			},
+			data.ImportStep(),
+			{
 				Config: testAccApplication_appRoles(data.RandomInteger),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckApplicationExists(data.ResourceName),
@@ -261,31 +269,11 @@ func TestAccApplication_appRolesUpdate(t *testing.T) {
 				),
 			},
 			data.ImportStep(),
-		},
-	})
-}
-
-func TestAccApplication_appRolesDelete(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azuread_application", "test")
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acceptance.PreCheck(t) },
-		Providers:    acceptance.SupportedProviders,
-		CheckDestroy: testCheckApplicationDestroy,
-		Steps: []resource.TestStep{
 			{
-				Config: testAccApplication_appRolesUpdate(data.RandomInteger),
+				Config: testAccApplication_appRolesEmpty(data.RandomInteger),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckApplicationExists(data.ResourceName),
-					resource.TestCheckResourceAttr(data.ResourceName, "app_role.#", "2"),
-				),
-			},
-			data.ImportStep(),
-			{
-				Config: testAccApplication_appRoles(data.RandomInteger),
-				Check: resource.ComposeTestCheckFunc(
-					testCheckApplicationExists(data.ResourceName),
-					resource.TestCheckResourceAttr(data.ResourceName, "app_role.#", "1"),
+					resource.TestCheckResourceAttr(data.ResourceName, "app_role.#", "0"),
 				),
 			},
 			data.ImportStep(),
@@ -838,6 +826,16 @@ resource "azuread_application" "test" {
     is_enabled           = true
     value                = "User"
   }
+}
+`, ri)
+}
+
+func testAccApplication_appRolesEmpty(ri int) string {
+	return fmt.Sprintf(`
+resource "azuread_application" "test" {
+  name = "acctestApp-%d"
+
+  app_role = []
 }
 `, ri)
 }


### PR DESCRIPTION
There are a set of small bugs which can occur by updating immediately after creating an application, mostly around the reliance on `d.GetChange()`, which is always true in this scenario.

This PR refactors the update logic for the `app_role` and `oauth2_permissions` properties into a helper function, and stops returning `applicationResourceUpdate()` at the end of `applicationResourceCreate()`. Additionally fixes up the setting of `prevent_duplicate_names` on read to avoid unwanted diffs, and adds regression test coverage for that attribute.

Sets `ConfigMode: schema.SchemaConfigModeAttr` on the `app_role` attribute to enable specifying an empty list in order to remove existing app roles. As with the other optional+computed attributes, this only works on update and if a config change is detected. Test also amended for this case.

Resolves #364